### PR TITLE
Azure DevOps VSC: add basic PAT auth support

### DIFF
--- a/ai_review/clients/azure_devops/auth.py
+++ b/ai_review/clients/azure_devops/auth.py
@@ -1,0 +1,31 @@
+from base64 import b64encode
+
+from ai_review.libs.config.vcs.azure_devops import AzureDevOpsTokenType
+
+
+def build_authorization_header(token: str, token_type: AzureDevOpsTokenType) -> str:
+    """
+    Build an Authorization header value based on the token type.
+
+    Args:
+        token: The API token value (OAuth2 token or PAT)
+        token_type: The authentication mode (OAUTH2 or PAT)
+
+    Returns:
+        Authorization header value in the format:
+        - "Bearer {token}" for OAUTH2
+        - "Basic {base64(:{token})}" for PAT
+
+    Note:
+        For PAT authentication, Azure DevOps requires the format ":{token}"
+        to be base64-encoded (empty username with colon prefix).
+    """
+    if token_type == AzureDevOpsTokenType.OAUTH2:
+        return f"Bearer {token}"
+    elif token_type == AzureDevOpsTokenType.PAT:
+        # Azure DevOps PAT format: base64 encode ":{token}" (empty username)
+        credentials = f":{token}"
+        encoded = b64encode(credentials.encode()).decode()
+        return f"Basic {encoded}"
+    else:
+        raise ValueError(f"Unsupported token type: {token_type}")

--- a/ai_review/clients/azure_devops/client.py
+++ b/ai_review/clients/azure_devops/client.py
@@ -1,5 +1,6 @@
 from httpx import AsyncClient, AsyncHTTPTransport
 
+from ai_review.clients.azure_devops.auth import build_authorization_header
 from ai_review.clients.azure_devops.pr.client import AzureDevOpsPullRequestsHTTPClient
 from ai_review.config import settings
 from ai_review.libs.http.event_hooks.logger import LoggerEventHook
@@ -20,10 +21,15 @@ def get_azure_devops_http_client() -> AzureDevOpsHTTPClient:
         transport=AsyncHTTPTransport(verify=settings.vcs.http_client.verify)
     )
 
+    auth_header = build_authorization_header(
+        token=settings.vcs.http_client.api_token_value,
+        token_type=settings.vcs.http_client.api_token_type
+    )
+
     client = AsyncClient(
         verify=settings.vcs.http_client.verify,
         timeout=settings.vcs.http_client.timeout,
-        headers={"Authorization": f"Bearer {settings.vcs.http_client.api_token_value}"},
+        headers={"Authorization": auth_header},
         base_url=settings.vcs.http_client.api_url_value,
         transport=retry_transport,
         event_hooks={

--- a/ai_review/libs/config/vcs/azure_devops.py
+++ b/ai_review/libs/config/vcs/azure_devops.py
@@ -1,6 +1,13 @@
-from pydantic import BaseModel
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
 
 from ai_review.libs.config.http import HTTPClientWithTokenConfig
+
+
+class AzureDevOpsTokenType(StrEnum):
+    OAUTH2 = "OAUTH2"
+    PAT = "PAT"
 
 
 class AzureDevOpsPipelineConfig(BaseModel):
@@ -13,3 +20,6 @@ class AzureDevOpsPipelineConfig(BaseModel):
 
 class AzureDevOpsHTTPClientConfig(HTTPClientWithTokenConfig):
     api_version: str = "7.0"
+    api_token_type: AzureDevOpsTokenType = Field(
+        default=AzureDevOpsTokenType.OAUTH2
+    )

--- a/ai_review/tests/fixtures/clients/azure_devops.py
+++ b/ai_review/tests/fixtures/clients/azure_devops.py
@@ -257,3 +257,27 @@ def azure_devops_http_client_config(monkeypatch: pytest.MonkeyPatch):
         )
     )
     monkeypatch.setattr(settings, "vcs", fake_config)
+
+
+@pytest.fixture
+def azure_devops_http_client_config_with_pat(monkeypatch: pytest.MonkeyPatch):
+    """Azure DevOps config with PAT authentication."""
+    from ai_review.libs.config.vcs.azure_devops import AzureDevOpsTokenType
+    
+    fake_config = AzureDevOpsVCSConfig(
+        provider=VCSProvider.AZURE_DEVOPS,
+        pipeline=AzureDevOpsPipelineConfig(
+            organization="org",
+            project="proj",
+            repository_id="repo123",
+            pull_request_id=5,
+            iteration_id=7,
+        ),
+        http_client=AzureDevOpsHTTPClientConfig(
+            timeout=10,
+            api_url=HttpUrl("https://dev.azure.com/org"),
+            api_token=SecretStr("fake-pat-token"),
+            api_token_type=AzureDevOpsTokenType.PAT
+        )
+    )
+    monkeypatch.setattr(settings, "vcs", fake_config)

--- a/ai_review/tests/suites/clients/azure_devops/test_auth.py
+++ b/ai_review/tests/suites/clients/azure_devops/test_auth.py
@@ -1,0 +1,28 @@
+from base64 import b64decode
+
+from ai_review.clients.azure_devops.auth import build_authorization_header
+from ai_review.libs.config.vcs.azure_devops import AzureDevOpsTokenType
+
+
+def test_build_authorization_header_oauth2():
+    """Should return Bearer token format for OAuth2."""
+    token = "test-oauth2-token-12345"
+    result = build_authorization_header(token, AzureDevOpsTokenType.OAUTH2)
+    
+    assert result == f"Bearer {token}"
+
+
+def test_build_authorization_header_pat():
+    """Should return Basic auth format with base64-encoded :token for PAT."""
+    token = "test-pat-token-67890"
+    result = build_authorization_header(token, AzureDevOpsTokenType.PAT)
+    
+    # Verify format
+    assert result.startswith("Basic ")
+    
+    # Extract and decode the base64 portion
+    encoded_part = result.replace("Basic ", "")
+    decoded = b64decode(encoded_part).decode()
+    
+    # Verify it matches the expected format ":token"
+    assert decoded == f":{token}"

--- a/ai_review/tests/suites/clients/azure_devops/test_client.py
+++ b/ai_review/tests/suites/clients/azure_devops/test_client.py
@@ -1,8 +1,17 @@
 import pytest
 from httpx import AsyncClient
+from pydantic import HttpUrl, SecretStr, ValidationError
 
 from ai_review.clients.azure_devops.client import get_azure_devops_http_client, AzureDevOpsHTTPClient
 from ai_review.clients.azure_devops.pr.client import AzureDevOpsPullRequestsHTTPClient
+from ai_review.config import settings
+from ai_review.libs.config.vcs.azure_devops import (
+    AzureDevOpsHTTPClientConfig,
+    AzureDevOpsPipelineConfig,
+    AzureDevOpsTokenType
+)
+from ai_review.libs.config.vcs.base import AzureDevOpsVCSConfig
+from ai_review.libs.constants.vcs_provider import VCSProvider
 
 
 @pytest.mark.usefixtures("azure_devops_http_client_config")
@@ -12,3 +21,111 @@ def test_get_azure_devops_http_client_builds_ok():
     assert isinstance(azure_devops_http_client, AzureDevOpsHTTPClient)
     assert isinstance(azure_devops_http_client.pr, AzureDevOpsPullRequestsHTTPClient)
     assert isinstance(azure_devops_http_client.pr.client, AsyncClient)
+
+
+def test_config_default_token_type_is_oauth2():
+    """Should default to OAUTH2 when api_token_type is not specified."""
+    config = AzureDevOpsHTTPClientConfig(
+        api_url=HttpUrl("https://dev.azure.com/org"),
+        api_token=SecretStr("test-token")
+    )
+    
+    assert config.token_type == AzureDevOpsTokenType.OAUTH2
+
+
+def test_config_accepts_valid_token_types():
+    """Should accept both 'oauth2' and 'pat' as valid token types."""
+    # Test oauth2
+    config_oauth = AzureDevOpsHTTPClientConfig(
+        api_url=HttpUrl("https://dev.azure.com/org"),
+        api_token=SecretStr("test-token"),
+        api_token_type=AzureDevOpsTokenType.OAUTH2
+    )
+    assert config_oauth.token_type == AzureDevOpsTokenType.OAUTH2
+    
+    # Test pat
+    config_pat = AzureDevOpsHTTPClientConfig(
+        api_url=HttpUrl("https://dev.azure.com/org"),
+        api_token=SecretStr("test-token"),
+        api_token_type=AzureDevOpsTokenType.PAT
+    )
+    assert config_pat.token_type == AzureDevOpsTokenType.PAT
+
+
+def test_config_rejects_invalid_token_type():
+    """Should raise ValidationError for invalid api_token_type values."""
+    invalid_values = ["bearer", "basic", "foo"]
+    
+    for invalid_value in invalid_values:
+        with pytest.raises(ValidationError) as exc_info:
+            AzureDevOpsHTTPClientConfig(
+                api_url=HttpUrl("https://dev.azure.com/org"),
+                api_token=SecretStr("test-token"),
+                api_token_type=invalid_value
+            )
+        
+        # Verify error message contains useful information
+        error_message = str(exc_info.value)
+        assert "token_type" in error_message.lower()
+
+
+def test_client_builds_with_oauth2_token_type(monkeypatch: pytest.MonkeyPatch):
+    """Should successfully build HTTP client with oauth2 token type."""
+    fake_config = AzureDevOpsVCSConfig(
+        provider=VCSProvider.AZURE_DEVOPS,
+        pipeline=AzureDevOpsPipelineConfig(
+            organization="org",
+            project="proj",
+            repository_id="repo123",
+            pull_request_id=5,
+            iteration_id=7,
+        ),
+        http_client=AzureDevOpsHTTPClientConfig(
+            timeout=10,
+            api_url=HttpUrl("https://dev.azure.com/org"),
+            api_token=SecretStr("fake-oauth-token"),
+            api_token_type=AzureDevOpsTokenType.OAUTH2
+        )
+    )
+    monkeypatch.setattr(settings, "vcs", fake_config)
+    
+    client = get_azure_devops_http_client()
+    
+    assert isinstance(client, AzureDevOpsHTTPClient)
+    assert isinstance(client.pr.client, AsyncClient)
+    
+    # Verify authorization header format
+    auth_header = client.pr.client.headers.get("Authorization")
+    assert auth_header is not None
+    assert auth_header.startswith("Bearer ")
+
+
+def test_client_builds_with_pat_token_type(monkeypatch: pytest.MonkeyPatch):
+    """Should successfully build HTTP client with pat token type."""
+    fake_config = AzureDevOpsVCSConfig(
+        provider=VCSProvider.AZURE_DEVOPS,
+        pipeline=AzureDevOpsPipelineConfig(
+            organization="org",
+            project="proj",
+            repository_id="repo123",
+            pull_request_id=5,
+            iteration_id=7,
+        ),
+        http_client=AzureDevOpsHTTPClientConfig(
+            timeout=10,
+            api_url=HttpUrl("https://dev.azure.com/org"),
+            api_token=SecretStr("fake-pat-token"),
+            api_token_type=AzureDevOpsTokenType.PAT
+        )
+    )
+    monkeypatch.setattr(settings, "vcs", fake_config)
+    
+    client = get_azure_devops_http_client()
+    
+    assert isinstance(client, AzureDevOpsHTTPClient)
+    assert isinstance(client.pr.client, AsyncClient)
+    
+    # Verify authorization header format
+    auth_header = client.pr.client.headers.get("Authorization")
+    assert auth_header is not None
+    assert auth_header.startswith("Basic ")

--- a/docs/ci/azure-devops.yaml
+++ b/docs/ci/azure-devops.yaml
@@ -15,7 +15,7 @@
 # Requirements:
 #   • Variable group "ai-review-secrets" with:
 #       - LLM__HTTP_CLIENT__API_TOKEN  (e.g., OpenAI API key)
-#       - VCS__HTTP_CLIENT__API_TOKEN  (Azure DevOps PAT with Code → Read & Write permissions)
+#       - VCS__HTTP_CLIENT__API_TOKEN  (Azure DevOps PAT or OAuth2 token with Code → Read & Write permissions)
 #   • Docker image: nikitafilonov/ai-review:latest
 # ===============================
 
@@ -30,33 +30,33 @@ variables:
 parameters:
   - name: ORGANIZATION
     type: string
-    default: 'rqcalculator'
-    displayName: 'Azure DevOps organization (name or URL prefix)'
+    default: "rqcalculator"
+    displayName: "Azure DevOps organization (name or URL prefix)"
 
   - name: PROJECT
     type: string
-    default: 'test-ai-review'
-    displayName: 'Azure DevOps project'
+    default: "test-ai-review"
+    displayName: "Azure DevOps project"
 
   - name: REPOSITORY_ID
     type: string
-    default: 'ai-review-demo'
-    displayName: 'Repository ID (name or GUID)'
+    default: "ai-review-demo"
+    displayName: "Repository ID (name or GUID)"
 
   - name: PULL_REQUEST_ID
     type: string
-    default: '1'
-    displayName: 'Pull Request ID'
+    default: "1"
+    displayName: "Pull Request ID"
 
   - name: ITERATION_ID
     type: string
-    default: '1'
-    displayName: 'Iteration ID (PR review iteration)'
+    default: "1"
+    displayName: "Iteration ID (PR review iteration)"
 
   - name: COMMAND
     type: string
-    default: 'run'
-    displayName: 'AI Review command'
+    default: "run"
+    displayName: "AI Review command"
     values:
       - run
       - run-inline
@@ -102,6 +102,8 @@ jobs:
           VCS__HTTP_CLIENT__VERIFY: "true"
           VCS__HTTP_CLIENT__TIMEOUT: "120"
           VCS__HTTP_CLIENT__API_TOKEN: $(VCS__HTTP_CLIENT__API_TOKEN)
+          # Token type: "OAUTH2" (default, Bearer auth) or "PAT" (Personal Access Token, Basic auth)
+          # VCS__HTTP_CLIENT__API_TOKEN_TYPE: "PAT"  # Uncomment to use PAT authentication
 
           # ===============================
           # LLM provider & model

--- a/docs/configs/.ai-review.yaml
+++ b/docs/configs/.ai-review.yaml
@@ -161,8 +161,11 @@ vcs:
 
     # --- Azure DevOps ---
     # api_url: https://dev.azure.com  # Base API endpoint for your organization
-    # api_token: ${AZURE_DEVOPS_PAT}  # Personal Access Token (PAT) with Code → Read & Write permissions
+    # api_token: ${AZURE_DEVOPS_PAT}  # Personal Access Token (PAT) or OAuth2 token with Code → Read & Write permissions
     # api_version: 7.0                # API version (default: 7.0, can be overridden if needed)
+    # api_token_type: OAUTH2          # Authentication mode: "OAUTH2" (default, Bearer) or "PAT" (Basic auth)
+    #                                 # - OAUTH2: Uses Bearer token (default, backward compatible)
+    #                                 # - PAT: Uses Personal Access Token with Basic auth (base64 encoded :{token})
 
     # --- Gitea ---
     # api_url: https://gitea.mycompany.com/api/v1


### PR DESCRIPTION
I use an on-premises installation of Azure DevOps Server (not the most recent version), which does not support OAuth and bearer tokens.

It supports Personal Access Tokens, which are encoded differently and are not currently supported by ai-review.

This PR will add such support.

For the reference: [Use personal access tokens](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#use-a-pat) in Azure DevOps docs.
