### PR TITLE
fix(gitea): re-raise in get_review_info() instead of silently returning empty schema

### DIFF
--- a/ai_review/services/vcs/gitea/client.py
+++ b/ai_review/services/vcs/gitea/client.py
@@ -58,7 +58,7 @@ class GiteaVCSClient(VCSClientProtocol):
             )
         except Exception as error:
             logger.exception(f"Failed to fetch PR info {self.pull_request_ref}: {error}")
-            return ReviewInfoSchema()
+            raise
 
     # --- Comments ---
     async def get_general_comments(self) -> list[ReviewCommentSchema]:


### PR DESCRIPTION
## Problem

When `get_pull_request()` raises an exception (most commonly a 404 due to a misconfigured `VCS__HTTP_CLIENT__API_URL`), `get_review_info()` catches it and returns an empty `ReviewInfoSchema()`:

```python
except Exception as error:
    logger.exception(f"Failed to fetch PR info ...")
    return ReviewInfoSchema()   # ← changed_files is []
```

An empty `ReviewInfoSchema` means `changed_files=[]`. Every runner then logs **"No files to review"** and returns early. The process exits 0 and prints **"AI review completed successfully!"** — a false green that completely hides the misconfiguration.

### Reproduction

Set `VCS__HTTP_CLIENT__API_URL` to `https://your-gitea-host` (missing `/api/v1`) instead of `https://your-gitea-host/api/v1`. The job passes with no comments posted.

## Fix

Re-raise the exception so the process exits non-zero and the CI job correctly fails:

```python
except Exception as error:
    logger.exception(f"Failed to fetch PR info ...")
    raise
```

This is a one-line change. The error is already logged by `logger.exception`, so no information is lost — we just stop swallowing it.

## Why not return an empty schema?

Returning `ReviewInfoSchema()` makes sense for transient/partial failures (e.g. a single file's diff can't be fetched). But `get_review_info()` is the foundational call that determines what the entire review operates on. If it fails, there is no meaningful degraded mode — the review simply didn't happen, and silently pretending otherwise is worse than failing loudly.