### PR TITLE
Fixing #89 - All AI comments are linked to single file in Azure DevOps

### DIFF
--- a/ai_review/clients/azure_devops/pr/schema/files.py
+++ b/ai_review/clients/azure_devops/pr/schema/files.py
@@ -31,6 +31,7 @@ class AzureDevOpsPRChangeSchema(BaseModel):
 
     item: AzureDevOpsPRItemSchema
     change_type: str = Field(alias="changeType")
+    change_tracking_id: int | None = Field(alias="changeTrackingId", default=None)
 
 
 class AzureDevOpsGetPRFilesQuerySchema(BaseModel):

--- a/ai_review/services/vcs/azure_devops/client.py
+++ b/ai_review/services/vcs/azure_devops/client.py
@@ -34,7 +34,6 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
         self.pull_request_ref = (
             f"{self.organization}/{self.project}/{self.repository_id}#{self.pull_request_id}"
         )
-        self.change_tracking_ids: dict[str, int] = {}
 
     # --- Review info ---
     async def get_review_info(self) -> ReviewInfoSchema:
@@ -57,12 +56,6 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
             logger.info(
                 f"Fetched PR info for {self.pull_request_ref}"
             )
-
-            self.change_tracking_ids = {
-                change.item.path: change.change_tracking_id
-                for change in files.change_entries
-                if change.item and change.item.path and change.change_tracking_id is not None
-            }
 
             return ReviewInfoSchema(
                 id=pr.pull_request_id,
@@ -176,9 +169,29 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in {self.pull_request_ref}: {error}")
             raise
 
+    async def _resolve_change_tracking_id(self, file: str) -> int:
+        files = await self.http_client.pr.get_files(
+            organization=self.organization,
+            project=self.project,
+            repository_id=self.repository_id,
+            pull_request_id=self.pull_request_id,
+            iteration_id=self.iteration_id,
+        )
+
+        for change in files.change_entries:
+            if change.item and change.item.path == file and change.change_tracking_id is not None:
+                return change.change_tracking_id
+
+        logger.warning(
+            f"Failed to resolve change_tracking_id for {file} in {self.pull_request_ref}. "
+            f"Falling back to default change_tracking_id=1"
+        )
+        return 1
+
     async def create_inline_comment(self, file: str, line: int, message: str) -> None:
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
+            change_tracking_id = await self._resolve_change_tracking_id(file)
 
             request = AzureDevOpsCreatePRThreadRequestSchema(
                 comments=[AzureDevOpsCreatePRCommentRequestSchema(content=message)],
@@ -192,7 +205,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
                         first_comparing_iteration=self.iteration_id,
                         second_comparing_iteration=self.iteration_id,
                     ),
-                    change_tracking_id=self.change_tracking_ids.get(file, 1),
+                    change_tracking_id=change_tracking_id,
                 ),
             )
 

--- a/ai_review/services/vcs/azure_devops/client.py
+++ b/ai_review/services/vcs/azure_devops/client.py
@@ -34,7 +34,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
         self.pull_request_ref = (
             f"{self.organization}/{self.project}/{self.repository_id}#{self.pull_request_id}"
         )
-        self._change_tracking_ids: dict[str, int] = {}
+        self.change_tracking_ids: dict[str, int] = {}
 
     # --- Review info ---
     async def get_review_info(self) -> ReviewInfoSchema:
@@ -58,7 +58,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
                 f"Fetched PR info for {self.pull_request_ref}"
             )
 
-            self._change_tracking_ids = {
+            self.change_tracking_ids = {
                 change.item.path: change.change_tracking_id
                 for change in files.change_entries
                 if change.item and change.item.path and change.change_tracking_id is not None
@@ -192,7 +192,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
                         first_comparing_iteration=self.iteration_id,
                         second_comparing_iteration=self.iteration_id,
                     ),
-                    change_tracking_id=self._change_tracking_ids.get(file, 1),
+                    change_tracking_id=self.change_tracking_ids.get(file, 1),
                 ),
             )
 

--- a/ai_review/services/vcs/azure_devops/client.py
+++ b/ai_review/services/vcs/azure_devops/client.py
@@ -34,6 +34,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
         self.pull_request_ref = (
             f"{self.organization}/{self.project}/{self.repository_id}#{self.pull_request_id}"
         )
+        self._change_tracking_ids: dict[str, int] = {}
 
     # --- Review info ---
     async def get_review_info(self) -> ReviewInfoSchema:
@@ -56,6 +57,12 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
             logger.info(
                 f"Fetched PR info for {self.pull_request_ref}"
             )
+
+            self._change_tracking_ids = {
+                change.item.path: change.change_tracking_id
+                for change in files.change_entries
+                if change.item and change.item.path and change.change_tracking_id is not None
+            }
 
             return ReviewInfoSchema(
                 id=pr.pull_request_id,
@@ -185,7 +192,7 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
                         first_comparing_iteration=self.iteration_id,
                         second_comparing_iteration=self.iteration_id,
                     ),
-                    change_tracking_id=1,
+                    change_tracking_id=self._change_tracking_ids.get(file, 1),
                 ),
             )
 

--- a/ai_review/tests/fixtures/clients/azure_devops.py
+++ b/ai_review/tests/fixtures/clients/azure_devops.py
@@ -101,14 +101,16 @@ class FakeAzureDevOpsPullRequestsHTTPClient(AzureDevOpsPullRequestsHTTPClientPro
                         path="src/app.py",
                         object_id="1",
                     ),
-                    change_type="edit"
+                    change_type="edit",
+                    change_tracking_id=1
                 ),
                 AzureDevOpsPRChangeSchema(
                     item=AzureDevOpsPRItemSchema(
                         path="src/utils/helper.py",
                         object_id="2",
                     ),
-                    change_type="add"
+                    change_type="add",
+                    change_tracking_id=2
                 ),
             ]
         )

--- a/ai_review/tests/suites/services/vcs/azure_devops/test_client.py
+++ b/ai_review/tests/suites/services/vcs/azure_devops/test_client.py
@@ -37,6 +37,12 @@ async def test_get_review_info_returns_valid_schema(
     called_methods = [name for name, _ in fake_azure_devops_pull_requests_http_client.calls]
     assert called_methods == ["get_pull_request", "get_files"]
 
+    # Verify change_tracking_ids were properly populated from PR files response (issue #89 fix)
+    assert azure_devops_vcs_client.change_tracking_ids == {
+        "src/app.py": 1,
+        "src/utils/helper.py": 2,
+    }
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("azure_devops_http_client_config")
@@ -101,6 +107,9 @@ async def test_create_inline_comment_posts_comment_with_context(
         fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
 ):
     """Should create inline comment with proper thread context."""
+    # First call get_review_info to populate change_tracking_ids
+    await azure_devops_vcs_client.get_review_info()
+    
     await azure_devops_vcs_client.create_inline_comment("src/app.py", 10, "Looks good!")
 
     calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
@@ -111,6 +120,8 @@ async def test_create_inline_comment_posts_comment_with_context(
     assert request.thread_context.file_path == "src/app.py"
     assert request.thread_context.right_file_start.line == 10
     assert request.comments[0].content == "Looks good!"
+    # Verify correct change_tracking_id is used based on file path (issue #89 fix)
+    assert request.pull_request_thread_context.change_tracking_id == 1
 
 
 @pytest.mark.asyncio
@@ -277,3 +288,48 @@ async def test_delete_inline_comment_calls_delete_thread(
     assert call_args["project"] == "proj"
     assert call_args["repository_id"] == "repo123"
     assert call_args["pull_request_id"] == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("azure_devops_http_client_config")
+async def test_create_inline_comment_uses_correct_change_tracking_id_per_file(
+        azure_devops_vcs_client: AzureDevOpsVCSClient,
+        fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
+):
+    """Should use file-specific change_tracking_id instead of hardcoded 1 (issue #89)."""
+    # Populate change_tracking_ids from PR files
+    await azure_devops_vcs_client.get_review_info()
+
+    # Comment on first file (change_tracking_id = 1)
+    await azure_devops_vcs_client.create_inline_comment("src/app.py", 5, "Comment 1")
+
+    # Comment on second file (change_tracking_id = 2)
+    await azure_devops_vcs_client.create_inline_comment("src/utils/helper.py", 15, "Comment 2")
+
+    calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
+    assert len(calls) == 2
+
+    # First comment should use tracking ID 1
+    assert calls[0]["request"].pull_request_thread_context.change_tracking_id == 1
+    # Second comment should use tracking ID 2
+    assert calls[1]["request"].pull_request_thread_context.change_tracking_id == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("azure_devops_http_client_config")
+async def test_create_inline_comment_fallback_to_default_change_tracking_id(
+        azure_devops_vcs_client: AzureDevOpsVCSClient,
+        fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
+):
+    """Should fallback to 1 for unknown files without change_tracking_id."""
+    # Populate change_tracking_ids
+    await azure_devops_vcs_client.get_review_info()
+
+    # Comment on a file not in the PR
+    await azure_devops_vcs_client.create_inline_comment("unknown/file.py", 10, "Comment")
+
+    calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
+    assert len(calls) == 1
+
+    # Should fallback to default value 1
+    assert calls[0]["request"].pull_request_thread_context.change_tracking_id == 1

--- a/ai_review/tests/suites/services/vcs/azure_devops/test_client.py
+++ b/ai_review/tests/suites/services/vcs/azure_devops/test_client.py
@@ -37,12 +37,6 @@ async def test_get_review_info_returns_valid_schema(
     called_methods = [name for name, _ in fake_azure_devops_pull_requests_http_client.calls]
     assert called_methods == ["get_pull_request", "get_files"]
 
-    # Verify change_tracking_ids were properly populated from PR files response (issue #89 fix)
-    assert azure_devops_vcs_client.change_tracking_ids == {
-        "src/app.py": 1,
-        "src/utils/helper.py": 2,
-    }
-
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("azure_devops_http_client_config")
@@ -107,10 +101,10 @@ async def test_create_inline_comment_posts_comment_with_context(
         fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
 ):
     """Should create inline comment with proper thread context."""
-    # First call get_review_info to populate change_tracking_ids
-    await azure_devops_vcs_client.get_review_info()
-    
     await azure_devops_vcs_client.create_inline_comment("src/app.py", 10, "Looks good!")
+
+    called_methods = [name for name, _ in fake_azure_devops_pull_requests_http_client.calls]
+    assert called_methods == ["get_files", "create_thread"]
 
     calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
     assert len(calls) == 1
@@ -120,7 +114,6 @@ async def test_create_inline_comment_posts_comment_with_context(
     assert request.thread_context.file_path == "src/app.py"
     assert request.thread_context.right_file_start.line == 10
     assert request.comments[0].content == "Looks good!"
-    # Verify correct change_tracking_id is used based on file path (issue #89 fix)
     assert request.pull_request_thread_context.change_tracking_id == 1
 
 
@@ -297,21 +290,16 @@ async def test_create_inline_comment_uses_correct_change_tracking_id_per_file(
         fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
 ):
     """Should use file-specific change_tracking_id instead of hardcoded 1 (issue #89)."""
-    # Populate change_tracking_ids from PR files
-    await azure_devops_vcs_client.get_review_info()
-
-    # Comment on first file (change_tracking_id = 1)
     await azure_devops_vcs_client.create_inline_comment("src/app.py", 5, "Comment 1")
-
-    # Comment on second file (change_tracking_id = 2)
     await azure_devops_vcs_client.create_inline_comment("src/utils/helper.py", 15, "Comment 2")
+
+    called_methods = [name for name, _ in fake_azure_devops_pull_requests_http_client.calls]
+    assert called_methods == ["get_files", "create_thread", "get_files", "create_thread"]
 
     calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
     assert len(calls) == 2
 
-    # First comment should use tracking ID 1
     assert calls[0]["request"].pull_request_thread_context.change_tracking_id == 1
-    # Second comment should use tracking ID 2
     assert calls[1]["request"].pull_request_thread_context.change_tracking_id == 2
 
 
@@ -322,14 +310,12 @@ async def test_create_inline_comment_fallback_to_default_change_tracking_id(
         fake_azure_devops_pull_requests_http_client: FakeAzureDevOpsPullRequestsHTTPClient,
 ):
     """Should fallback to 1 for unknown files without change_tracking_id."""
-    # Populate change_tracking_ids
-    await azure_devops_vcs_client.get_review_info()
-
-    # Comment on a file not in the PR
     await azure_devops_vcs_client.create_inline_comment("unknown/file.py", 10, "Comment")
+
+    called_methods = [name for name, _ in fake_azure_devops_pull_requests_http_client.calls]
+    assert called_methods == ["get_files", "create_thread"]
 
     calls = [args for name, args in fake_azure_devops_pull_requests_http_client.calls if name == "create_thread"]
     assert len(calls) == 1
 
-    # Should fallback to default value 1
     assert calls[0]["request"].pull_request_thread_context.change_tracking_id == 1


### PR DESCRIPTION
Fixes Nikita-Filonov/ai-review#89

## Issue Summary

Despite correctly reporting AI comments for different files in pipeline logs, all comments in the pull request are wrongfully attached to one file.

## Root Cause Analysis

### Investigation

Traced the code flow:
1. `InlineReviewRunner.process_file()` → retrieves diff for each file 
2. Sends to LLM for review via `review_llm_gateway`
3. Returns comments with correct `file` and `line` properties
4. `ReviewCommentGateway.process_inline_comments()` → calls `vcs.create_inline_comment(file, line, message)` for each comment
5. `AzureDevOpsVCSClient.create_inline_comment()` → builds request with thread context

### The Bug

In `AzureDevOpsVCSClient.create_inline_comment()`, the `pull_request_thread_context` was hardcoded:

```python
pull_request_thread_context=AzureDevOpsPullRequestThreadContextSchema(
    iteration_context=AzureDevOpsIterationContextSchema(
        first_comparing_iteration=self.iteration_id,
        second_comparing_iteration=self.iteration_id,
    ),
    change_tracking_id=1,  # ← HARDCODED TO 1
),
```

In Azure DevOps, each changed file in a PR iteration has a unique `changeTrackingId`. When posting a thread (comment), this ID tells the API which file the comment belongs to. Using `1` for every comment causes all comments to attach to the first file.

The correct `changeTrackingId` values are available in the PR files response from Azure DevOps API, so they just need to be propagated correctly.