### PR TITLE
fix: handle noisy LLM output with prose or concatenated JSON objects

### DIFF
--- a/ai_review/libs/llm/output_json_parser.py
+++ b/ai_review/libs/llm/output_json_parser.py
@@ -13,6 +13,48 @@ T = TypeVar("T", bound=BaseModel)
 CLEAN_JSON_BLOCK_RE = re.compile(r"```(?:json)?(.*?)```", re.DOTALL | re.IGNORECASE)
 
 
+def iter_json_candidates(raw: str):
+    """Yield each top-level balanced {...} block found in *raw*.
+
+    Handles strings with escaped quotes so that braces inside JSON string
+    values are not counted.  When the prose before the real JSON payload
+    contains stray curly braces (e.g. ``Some {note} here\\n{"key":"val"}``),
+    every candidate is yielded and the caller decides which one is valid.
+    """
+    pos = 0
+    length = len(raw)
+    while pos < length:
+        start = raw.find("{", pos)
+        if start == -1:
+            break
+        depth = 0
+        in_string = False
+        escape = False
+        for i in range(start, length):
+            ch = raw[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\" and in_string:
+                escape = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    yield raw[start:i + 1]
+                    pos = i + 1
+                    break
+        else:
+            break
+
+
 class LLMOutputJSONParser(Generic[T]):
     """Reusable JSON parser for LLM responses."""
 
@@ -55,6 +97,17 @@ class LLMOutputJSONParser(Generic[T]):
         if parsed := self.try_parse(output):
             logger.info(f"[{self.model_name}] Successfully parsed")
             return parsed
+
+        for candidate in iter_json_candidates(output):
+            if candidate == output:
+                continue
+            logger.debug(
+                f"[{self.model_name}] Trying JSON candidate from noisy output "
+                f"(candidate_len={len(candidate)}, original_len={len(output)})"
+            )
+            if parsed := self.try_parse(candidate):
+                logger.info(f"[{self.model_name}] Successfully parsed JSON candidate from noisy output")
+                return parsed
 
         logger.error(f"[{self.model_name}] No valid JSON found in output")
         return None

--- a/ai_review/tests/suites/libs/llm/test_output_json_parser.py
+++ b/ai_review/tests/suites/libs/llm/test_output_json_parser.py
@@ -1,4 +1,4 @@
-from ai_review.libs.llm.output_json_parser import LLMOutputJSONParser, CLEAN_JSON_BLOCK_RE
+from ai_review.libs.llm.output_json_parser import LLMOutputJSONParser, CLEAN_JSON_BLOCK_RE, iter_json_candidates
 from ai_review.tests.fixtures.libs.llm.output_json_parser import DummyModel
 
 
@@ -153,3 +153,99 @@ def test_parse_output_with_extra_control_chars(llm_output_json_parser: LLMOutput
     result = llm_output_json_parser.try_parse(raw)
 
     assert result is None
+
+
+# ---------- iter_json_candidates ----------
+
+def test_iter_json_candidates_single():
+    """Should yield a single object for clean JSON."""
+    raw = '{"text": "hello"}'
+    assert list(iter_json_candidates(raw)) == [raw]
+
+
+def test_iter_json_candidates_concatenated():
+    """Should yield each object from concatenated JSON."""
+    raw = '{"text": "first"}{"text": "second"}'
+    assert list(iter_json_candidates(raw)) == ['{"text": "first"}', '{"text": "second"}']
+
+
+def test_iter_json_candidates_prose_prefix():
+    """Should yield the JSON object even when preceded by prose."""
+    raw = 'Let me analyze the diff for you.\n{"text": "found"}'
+    assert list(iter_json_candidates(raw)) == ['{"text": "found"}']
+
+
+def test_iter_json_candidates_nested_braces_in_string():
+    """Should correctly handle braces inside JSON string values."""
+    raw = '{"text": "a { nested } value"}'
+    assert list(iter_json_candidates(raw)) == [raw]
+
+
+def test_iter_json_candidates_escaped_quotes():
+    """Should handle escaped quotes inside string values."""
+    raw = '{"text": "she said \\"hello\\""}'
+    assert list(iter_json_candidates(raw)) == [raw]
+
+
+def test_iter_json_candidates_no_braces():
+    """Should yield nothing when there are no braces."""
+    assert list(iter_json_candidates("no json here")) == []
+
+
+def test_iter_json_candidates_unclosed():
+    """Should yield nothing for unclosed JSON."""
+    assert list(iter_json_candidates('{"text": "open')) == []
+
+
+def test_iter_json_candidates_prose_with_braces_before_json():
+    """Should yield both the stray brace block and the real JSON object."""
+    raw = 'Some prose with {curly braces} before JSON\n{"text": "actual"}'
+    candidates = list(iter_json_candidates(raw))
+    assert candidates == ["{curly braces}", '{"text": "actual"}']
+
+
+# ---------- parse_output: candidate fallback ----------
+
+def test_parse_output_concatenated_json_objects(llm_output_json_parser: LLMOutputJSONParser):
+    """Should parse first valid object when LLM returns two concatenated JSON objects."""
+    output = '{"text": "first"}{"text": "second"}'
+    result = llm_output_json_parser.parse_output(output)
+
+    assert isinstance(result, DummyModel)
+    assert result.text == "first"
+
+
+def test_parse_output_prose_before_json(llm_output_json_parser: LLMOutputJSONParser):
+    """Should parse JSON when LLM prepends prose before the object."""
+    output = 'Let me analyze the code.\n{"text": "actual"}'
+    result = llm_output_json_parser.parse_output(output)
+
+    assert isinstance(result, DummyModel)
+    assert result.text == "actual"
+
+
+def test_parse_output_prose_and_trailing_json(llm_output_json_parser: LLMOutputJSONParser):
+    """Should parse first valid JSON when LLM returns prose + object + another object."""
+    output = 'Here is my analysis:\n{"text": "result"}{"text": "extra"}'
+    result = llm_output_json_parser.parse_output(output)
+
+    assert isinstance(result, DummyModel)
+    assert result.text == "result"
+
+
+def test_parse_output_prose_with_braces_before_json(llm_output_json_parser: LLMOutputJSONParser):
+    """Should skip stray brace blocks in prose and parse the actual JSON object."""
+    output = 'Some prose with {curly braces} before JSON\n{"text": "actual"}'
+    result = llm_output_json_parser.parse_output(output)
+
+    assert isinstance(result, DummyModel)
+    assert result.text == "actual"
+
+
+def test_parse_output_multiple_stray_braces_before_json(llm_output_json_parser: LLMOutputJSONParser):
+    """Should skip multiple non-JSON brace groups in prose."""
+    output = 'I noticed {some} issues and {more stuff} here.\n{"text": "found"}'
+    result = llm_output_json_parser.parse_output(output)
+
+    assert isinstance(result, DummyModel)
+    assert result.text == "found"


### PR DESCRIPTION
Some models (e.g. gpt-5.4, claude-opus-4.6 via OpenRouter) violate the agent protocol by either prepending prose before the JSON object or emitting two concatenated JSON objects in a single response.

Add extract_first_json_object() that finds the first balanced {...} in the raw output by tracking brace depth, and use it as a fallback in parse_output() when the initial parse and sanitization both fail.
