### PR TITLE
Adding GPT-5 `max_completion_tokens` parameter support for AZURE_OPENAI connector

### DIFF
--- a/ai_review/clients/azure_openai/schema.py
+++ b/ai_review/clients/azure_openai/schema.py
@@ -34,6 +34,7 @@ class AzureOpenAIChatQuerySchema(BaseModel):
 class AzureOpenAIChatRequestSchema(BaseModel):
     messages: list[AzureOpenAIMessage]
     max_tokens: int | None = None
+    max_completion_tokens: int | None = None
     temperature: float | None = None
 
 

--- a/ai_review/libs/config/llm/meta.py
+++ b/ai_review/libs/config/llm/meta.py
@@ -4,4 +4,5 @@ from pydantic import BaseModel, Field
 class LLMMetaConfig(BaseModel):
     model: str
     max_tokens: int | None = Field(default=None, ge=1)
+    max_completion_tokens: int | None = Field(default=None, ge=1)
     temperature: float | None = Field(default=None, ge=0.0, le=2.0)

--- a/ai_review/services/llm/azure_openai/client.py
+++ b/ai_review/services/llm/azure_openai/client.py
@@ -9,13 +9,28 @@ class AzureOpenAILLMClient(LLMClientProtocol):
         self.http_client = get_azure_openai_http_client()
 
     async def chat(self, prompt: str, prompt_system: str) -> ChatResultSchema:
+        model_name = settings.llm.meta.model.lower()
+        use_max_completion_tokens = model_name.startswith("gpt-5")
+
+        max_tokens = settings.llm.meta.max_tokens
+        max_completion_tokens = None
+
+        if use_max_completion_tokens:
+            max_completion_tokens = (
+                settings.llm.meta.max_completion_tokens
+                if settings.llm.meta.max_completion_tokens is not None
+                else settings.llm.meta.max_tokens
+            )
+            max_tokens = None
+
         request = AzureOpenAIChatRequestSchema(
             messages=[
                 AzureOpenAIMessage(role="system", content=prompt_system),
                 AzureOpenAIMessage(role="user", content=prompt),
             ],
             temperature=settings.llm.meta.temperature,
-            max_tokens=settings.llm.meta.max_tokens,
+            max_tokens=max_tokens,
+            max_completion_tokens=max_completion_tokens,
         )
         response = await self.http_client.chat(request)
         return ChatResultSchema(

--- a/ai_review/tests/suites/clients/azure_openai/test_schema.py
+++ b/ai_review/tests/suites/clients/azure_openai/test_schema.py
@@ -107,10 +107,12 @@ def test_chat_request_schema_builds_ok():
             AzureOpenAIMessage(role="user", content="hello"),
         ],
         max_tokens=500,
+        max_completion_tokens=700,
         temperature=0.4,
     )
 
     assert req.messages[0].role == "system"
     assert req.messages[1].content == "hello"
     assert req.max_tokens == 500
+    assert req.max_completion_tokens == 700
     assert req.temperature == 0.4

--- a/ai_review/tests/suites/services/llm/azure_openai/test_client.py
+++ b/ai_review/tests/suites/services/llm/azure_openai/test_client.py
@@ -20,3 +20,57 @@ async def test_azure_openai_llm_chat(
     assert result.completion_tokens == 7
 
     assert fake_azure_openai_http_client.calls[0][0] == "chat"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("azure_openai_http_client_config")
+async def test_azure_openai_llm_chat_uses_max_completion_tokens_for_gpt5_fallback(
+        azure_openai_llm_client: AzureOpenAILLMClient,
+        fake_azure_openai_http_client: FakeAzureOpenAIHTTPClient,
+        monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.model", "GPT-5.4-mini")
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_tokens", 333)
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_completion_tokens", None)
+
+    await azure_openai_llm_client.chat("prompt", "prompt_system")
+
+    request = fake_azure_openai_http_client.calls[0][1]["request"]
+    assert request.max_tokens is None
+    assert request.max_completion_tokens == 333
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("azure_openai_http_client_config")
+async def test_azure_openai_llm_chat_uses_explicit_max_completion_tokens_for_gpt5(
+        azure_openai_llm_client: AzureOpenAILLMClient,
+        fake_azure_openai_http_client: FakeAzureOpenAIHTTPClient,
+        monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.model", "gpt-5.1")
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_tokens", 222)
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_completion_tokens", 777)
+
+    await azure_openai_llm_client.chat("prompt", "prompt_system")
+
+    request = fake_azure_openai_http_client.calls[0][1]["request"]
+    assert request.max_tokens is None
+    assert request.max_completion_tokens == 777
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("azure_openai_http_client_config")
+async def test_azure_openai_llm_chat_keeps_max_tokens_for_non_gpt5(
+        azure_openai_llm_client: AzureOpenAILLMClient,
+        fake_azure_openai_http_client: FakeAzureOpenAIHTTPClient,
+        monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.model", "gpt-4o-mini")
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_tokens", 444)
+    monkeypatch.setattr("ai_review.config.settings.llm.meta.max_completion_tokens", 999)
+
+    await azure_openai_llm_client.chat("prompt", "prompt_system")
+
+    request = fake_azure_openai_http_client.calls[0][1]["request"]
+    assert request.max_tokens == 444
+    assert request.max_completion_tokens is None


### PR DESCRIPTION
# Adding GPT-5 `max_completion_tokens` parameter support

Current `AZURE_OPENAI` connector builds request payload for the API with `max_tokens` parameter only.
For GPT-5 deployments this fails with:
 `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`

This PR adds `max_completion_tokens` parameter keeping backwards compatibility with the existing schema - user can either explicitly define `max_completion_tokens` for GPT-5 models or use old `max_tokens` which will be automatically changed to `max_completion_tokens` under the hood before sent to OpenAI.
