### PR TITLE
feat(gitlab): batch inline comments via draft notes (single notification)

### DIFF
--- a/ai_review/cli/commands/run_clear_inline_review.py
+++ b/ai_review/cli/commands/run_clear_inline_review.py
@@ -2,5 +2,5 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_clear_inline_review():
-    review_service = ReviewService()
-    await review_service.run_clear_inline_review()
+    async with ReviewService() as review_service:
+        await review_service.run_clear_inline_review()

--- a/ai_review/cli/commands/run_clear_summary_review.py
+++ b/ai_review/cli/commands/run_clear_summary_review.py
@@ -2,5 +2,5 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_clear_summary_review():
-    review_service = ReviewService()
-    await review_service.run_clear_summary_review()
+    async with ReviewService() as review_service:
+        await review_service.run_clear_summary_review()

--- a/ai_review/cli/commands/run_context_review.py
+++ b/ai_review/cli/commands/run_context_review.py
@@ -2,6 +2,6 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_context_review_command():
-    review_service = ReviewService()
-    await review_service.run_context_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_context_review()
+        review_service.report_total_cost()

--- a/ai_review/cli/commands/run_inline_reply_review.py
+++ b/ai_review/cli/commands/run_inline_reply_review.py
@@ -2,6 +2,6 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_inline_reply_review_command():
-    review_service = ReviewService()
-    await review_service.run_inline_reply_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_inline_reply_review()
+        review_service.report_total_cost()

--- a/ai_review/cli/commands/run_inline_review.py
+++ b/ai_review/cli/commands/run_inline_review.py
@@ -2,6 +2,6 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_inline_review_command():
-    review_service = ReviewService()
-    await review_service.run_inline_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_inline_review()
+        review_service.report_total_cost()

--- a/ai_review/cli/commands/run_review.py
+++ b/ai_review/cli/commands/run_review.py
@@ -2,7 +2,7 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_review_command():
-    review_service = ReviewService()
-    await review_service.run_inline_review()
-    await review_service.run_summary_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_inline_review()
+        await review_service.run_summary_review()
+        review_service.report_total_cost()

--- a/ai_review/cli/commands/run_summary_reply_review.py
+++ b/ai_review/cli/commands/run_summary_reply_review.py
@@ -2,6 +2,6 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_summary_reply_review_command():
-    review_service = ReviewService()
-    await review_service.run_summary_reply_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_summary_reply_review()
+        review_service.report_total_cost()

--- a/ai_review/cli/commands/run_summary_review.py
+++ b/ai_review/cli/commands/run_summary_review.py
@@ -2,6 +2,6 @@ from ai_review.services.review.service import ReviewService
 
 
 async def run_summary_review_command():
-    review_service = ReviewService()
-    await review_service.run_summary_review()
-    review_service.report_total_cost()
+    async with ReviewService() as review_service:
+        await review_service.run_summary_review()
+        review_service.report_total_cost()

--- a/ai_review/clients/gitlab/mr/client.py
+++ b/ai_review/clients/gitlab/mr/client.py
@@ -10,6 +10,10 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
     GitLabCreateMRDiscussionReplyRequestSchema,
     GitLabCreateMRDiscussionReplyResponseSchema
 )
+from ai_review.clients.gitlab.mr.schema.draft_notes import (
+    GitLabDraftNoteSchema,
+    GitLabCreateMRDraftNoteRequestSchema,
+)
 from ai_review.clients.gitlab.mr.schema.notes import (
     GitLabNoteSchema,
     GitLabGetMRNotesQuerySchema,
@@ -103,6 +107,24 @@ class GitLabMergeRequestsHTTPClient(HTTPClient, GitLabMergeRequestsHTTPClientPro
             f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/notes/{note_id}"
         )
 
+    @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
+    async def create_draft_note_api(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            request: GitLabCreateMRDraftNoteRequestSchema,
+    ) -> Response:
+        return await self.post(
+            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes",
+            json=request.model_dump(exclude_none=True),
+        )
+
+    @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
+    async def bulk_publish_draft_notes_api(self, project_id: str, merge_request_id: str) -> Response:
+        return await self.post(
+            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes/bulk_publish"
+        )
+
     async def get_changes(self, project_id: str, merge_request_id: str) -> GitLabGetMRChangesResponseSchema:
         response = await self.get_changes_api(project_id, merge_request_id)
         return GitLabGetMRChangesResponseSchema.model_validate_json(response.text)
@@ -194,3 +216,19 @@ class GitLabMergeRequestsHTTPClient(HTTPClient, GitLabMergeRequestsHTTPClientPro
 
     async def delete_note(self, project_id: str, merge_request_id: str, note_id: str) -> None:
         await self.delete_note_api(project_id, merge_request_id, note_id)
+
+    async def create_draft_note(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            request: GitLabCreateMRDraftNoteRequestSchema,
+    ) -> GitLabDraftNoteSchema:
+        response = await self.create_draft_note_api(
+            request=request,
+            project_id=project_id,
+            merge_request_id=merge_request_id,
+        )
+        return GitLabDraftNoteSchema.model_validate_json(response.text)
+
+    async def bulk_publish_draft_notes(self, project_id: str, merge_request_id: str) -> None:
+        await self.bulk_publish_draft_notes_api(project_id, merge_request_id)

--- a/ai_review/clients/gitlab/mr/schema/draft_notes.py
+++ b/ai_review/clients/gitlab/mr/schema/draft_notes.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
+
+
+class GitLabDraftNoteSchema(BaseModel):
+    id: int
+    note: str
+    position: GitLabPositionSchema | None = None
+
+
+class GitLabCreateMRDraftNoteRequestSchema(BaseModel):
+    note: str
+    position: GitLabPositionSchema | None = None

--- a/ai_review/clients/gitlab/mr/types.py
+++ b/ai_review/clients/gitlab/mr/types.py
@@ -7,6 +7,10 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
     GitLabCreateMRDiscussionResponseSchema,
     GitLabCreateMRDiscussionReplyResponseSchema
 )
+from ai_review.clients.gitlab.mr.schema.draft_notes import (
+    GitLabDraftNoteSchema,
+    GitLabCreateMRDraftNoteRequestSchema,
+)
 from ai_review.clients.gitlab.mr.schema.notes import GitLabGetMRNotesResponseSchema, GitLabCreateMRNoteResponseSchema
 
 
@@ -44,3 +48,12 @@ class GitLabMergeRequestsHTTPClientProtocol(Protocol):
     ) -> GitLabCreateMRDiscussionReplyResponseSchema: ...
 
     async def delete_note(self, project_id: str, merge_request_id: str, note_id: str) -> None: ...
+
+    async def create_draft_note(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            request: GitLabCreateMRDraftNoteRequestSchema,
+    ) -> GitLabDraftNoteSchema: ...
+
+    async def bulk_publish_draft_notes(self, project_id: str, merge_request_id: str) -> None: ...

--- a/ai_review/libs/config/vcs/base.py
+++ b/ai_review/libs/config/vcs/base.py
@@ -33,6 +33,9 @@ class GitLabVCSConfig(VCSConfigBase):
     provider: Literal[VCSProvider.GITLAB]
     pipeline: GitLabPipelineConfig
     http_client: GitLabHTTPClientConfig
+    # Post inline comments as draft notes and publish them in one batch,
+    # so reviewers get a single notification. Requires GitLab 15.10+.
+    batch_comments: bool = False
 
 
 class GitHubVCSConfig(VCSConfigBase):

--- a/ai_review/services/review/gateway/review_comment_gateway.py
+++ b/ai_review/services/review/gateway/review_comment_gateway.py
@@ -8,7 +8,12 @@ from ai_review.services.review.internal.inline.schema import InlineCommentListSc
 from ai_review.services.review.internal.inline_reply.schema import InlineCommentReplySchema
 from ai_review.services.review.internal.summary.schema import SummaryCommentSchema
 from ai_review.services.review.internal.summary_reply.schema import SummaryCommentReplySchema
-from ai_review.services.vcs.types import VCSClientProtocol, ReviewThreadSchema, ReviewCommentSchema
+from ai_review.services.vcs.types import (
+    VCSClientProtocol,
+    ReviewThreadSchema,
+    ReviewCommentSchema,
+    SupportsBatchedComments,
+)
 
 logger = get_logger("REVIEW_COMMENT_GATEWAY")
 
@@ -121,6 +126,15 @@ class ReviewCommentGateway(ReviewCommentGatewayProtocol):
 
     async def process_inline_comments(self, comments: InlineCommentListSchema) -> None:
         await bounded_gather([self.process_inline_comment(comment) for comment in comments.root])
+
+    async def finalize(self) -> None:
+        if not isinstance(self.vcs, SupportsBatchedComments):
+            return
+
+        try:
+            await self.vcs.publish_comments()
+        except Exception as error:
+            logger.exception(f"Failed to publish batched comments: {error}")
 
     async def clear_inline_comments(self) -> None:
         await hook.emit_clear_inline_comments_start()

--- a/ai_review/services/review/gateway/review_dry_run_comment_gateway.py
+++ b/ai_review/services/review/gateway/review_dry_run_comment_gateway.py
@@ -50,6 +50,9 @@ class ReviewDryRunCommentGateway(ReviewCommentGateway):
     async def process_inline_comments(self, comments: InlineCommentListSchema) -> None:
         await bounded_gather([self.process_inline_comment(comment) for comment in comments.root])
 
+    async def finalize(self) -> None:
+        logger.info("[dry-run] Would publish batched comments")
+
     async def clear_inline_comments(self) -> None:
         await hook.emit_clear_inline_comments_start()
 

--- a/ai_review/services/review/gateway/types.py
+++ b/ai_review/services/review/gateway/types.py
@@ -50,6 +50,9 @@ class ReviewCommentGatewayProtocol(Protocol):
     async def process_inline_comments(self, comments: InlineCommentListSchema) -> None:
         ...
 
+    async def finalize(self) -> None:
+        ...
+
     async def clear_inline_comments(self) -> None:
         ...
 

--- a/ai_review/services/review/service.py
+++ b/ai_review/services/review/service.py
@@ -129,6 +129,15 @@ class ReviewService:
             review_comment_gateway=self.review_comment_gateway
         )
 
+    async def __aenter__(self) -> "ReviewService":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        # Finalize even when the pipeline failed, so comments already
+        # accumulated in a pending batch (e.g. GitLab draft notes) are
+        # published instead of lingering invisibly as drafts.
+        await self.review_comment_gateway.finalize()
+
     async def run_inline_review(self) -> None:
         await self.inline_review_runner.run()
 

--- a/ai_review/services/vcs/gitlab/client.py
+++ b/ai_review/services/vcs/gitlab/client.py
@@ -1,5 +1,6 @@
 from ai_review.clients.gitlab.client import get_gitlab_http_client
 from ai_review.clients.gitlab.mr.schema.discussions import GitLabCreateMRDiscussionRequestSchema
+from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabCreateMRDraftNoteRequestSchema
 from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
 from ai_review.config import settings
 from ai_review.libs.logger import get_logger
@@ -23,6 +24,7 @@ class GitLabVCSClient(VCSClientProtocol):
         self.project_id = settings.vcs.pipeline.project_id
         self.merge_request_id = settings.vcs.pipeline.merge_request_id
         self.merge_request_ref = f"project_id={self.project_id} merge_request_id={self.merge_request_id}"
+        self.pending_comments = 0
 
     # --- Review info ---
     async def get_review_info(self) -> ReviewInfoSchema:
@@ -110,6 +112,10 @@ class GitLabVCSClient(VCSClientProtocol):
             return []
 
     async def create_general_comment(self, message: str) -> None:
+        if settings.vcs.batch_comments:
+            await self.create_draft_general_comment(message)
+            return
+
         try:
             logger.info(f"Posting general comment to {self.merge_request_ref}: {message}")
             await self.http_client.mr.create_note(
@@ -122,7 +128,26 @@ class GitLabVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in {self.merge_request_ref}: {error}")
             raise
 
+    async def create_draft_general_comment(self, message: str) -> None:
+        try:
+            logger.info(f"Adding draft general comment to {self.merge_request_ref}: {message}")
+            request = GitLabCreateMRDraftNoteRequestSchema(note=message)
+            await self.http_client.mr.create_draft_note(
+                request=request,
+                project_id=self.project_id,
+                merge_request_id=self.merge_request_id,
+            )
+            self.pending_comments += 1
+            logger.info(f"Created draft general comment in {self.merge_request_ref}")
+        except Exception as error:
+            logger.exception(f"Failed to create draft general comment in {self.merge_request_ref}: {error}")
+            raise
+
     async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+        if settings.vcs.batch_comments:
+            await self.create_draft_inline_comment(file=file, line=line, message=message)
+            return
+
         try:
             logger.info(f"Posting inline comment in {self.merge_request_ref} at {file}:{line}: {message}")
 
@@ -150,6 +175,55 @@ class GitLabVCSClient(VCSClientProtocol):
             logger.info(f"Created inline comment in {self.merge_request_ref} at {file}:{line}")
         except Exception as error:
             logger.exception(f"Failed to create inline comment in {self.merge_request_ref} at {file}:{line}: {error}")
+            raise
+
+    async def create_draft_inline_comment(self, file: str, line: int, message: str) -> None:
+        try:
+            logger.info(f"Adding draft inline comment in {self.merge_request_ref} at {file}:{line}: {message}")
+
+            response = await self.http_client.mr.get_changes(
+                project_id=self.project_id,
+                merge_request_id=self.merge_request_id,
+            )
+
+            request = GitLabCreateMRDraftNoteRequestSchema(
+                note=message,
+                position=GitLabPositionSchema(
+                    position_type="text",
+                    base_sha=response.diff_refs.base_sha,
+                    head_sha=response.diff_refs.head_sha,
+                    start_sha=response.diff_refs.start_sha,
+                    new_path=file,
+                    new_line=line,
+                ),
+            )
+            await self.http_client.mr.create_draft_note(
+                request=request,
+                project_id=self.project_id,
+                merge_request_id=self.merge_request_id,
+            )
+            self.pending_comments += 1
+            logger.info(f"Created draft inline comment in {self.merge_request_ref} at {file}:{line}")
+        except Exception as error:
+            logger.exception(
+                f"Failed to create draft inline comment in {self.merge_request_ref} at {file}:{line}: {error}"
+            )
+            raise
+
+    async def publish_comments(self) -> None:
+        if not settings.vcs.batch_comments or not self.pending_comments:
+            return
+
+        try:
+            logger.info(f"Publishing {self.pending_comments} draft comments in {self.merge_request_ref}")
+            await self.http_client.mr.bulk_publish_draft_notes(
+                project_id=self.project_id,
+                merge_request_id=self.merge_request_id,
+            )
+            self.pending_comments = 0
+            logger.info(f"Published draft comments in {self.merge_request_ref}")
+        except Exception as error:
+            logger.exception(f"Failed to publish draft comments in {self.merge_request_ref}: {error}")
             raise
 
     async def delete_general_comment(self, comment_id: int | str) -> None:

--- a/ai_review/services/vcs/types.py
+++ b/ai_review/services/vcs/types.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
@@ -102,3 +102,16 @@ class VCSClientProtocol(Protocol):
         Fetch grouped general (summary-level) comment threads.
         If VCS is flat (e.g. GitHub issues), each comment is a separate thread.
         """
+
+
+@runtime_checkable
+class SupportsBatchedComments(Protocol):
+    """
+    Optional capability for VCS clients that accumulate comments in a pending
+    batch (e.g. GitLab draft notes, GitHub pending reviews) instead of posting
+    them immediately. Clients that post comments directly simply don't
+    implement it.
+    """
+
+    async def publish_comments(self) -> None:
+        """Publish all comments accumulated in the pending batch."""

--- a/ai_review/tests/fixtures/clients/gitlab.py
+++ b/ai_review/tests/fixtures/clients/gitlab.py
@@ -14,6 +14,10 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
     GitLabCreateMRDiscussionResponseSchema,
     GitLabCreateMRDiscussionReplyResponseSchema,
 )
+from ai_review.clients.gitlab.mr.schema.draft_notes import (
+    GitLabDraftNoteSchema,
+    GitLabCreateMRDraftNoteRequestSchema,
+)
 from ai_review.clients.gitlab.mr.schema.notes import (
     GitLabNoteSchema,
     GitLabGetMRNotesResponseSchema,
@@ -175,6 +179,33 @@ class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
             )
         )
 
+    async def create_draft_note(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            request: GitLabCreateMRDraftNoteRequestSchema,
+    ) -> GitLabDraftNoteSchema:
+        self.calls.append(
+            (
+                "create_draft_note",
+                {
+                    "project_id": project_id,
+                    "merge_request_id": merge_request_id,
+                    "note": request.note,
+                    "position": request.position,
+                },
+            )
+        )
+        return GitLabDraftNoteSchema(id=500, note=request.note, position=request.position)
+
+    async def bulk_publish_draft_notes(self, project_id: str, merge_request_id: str) -> None:
+        self.calls.append(
+            (
+                "bulk_publish_draft_notes",
+                {"project_id": project_id, "merge_request_id": merge_request_id},
+            )
+        )
+
 
 class FakeGitLabHTTPClient:
     def __init__(self, merge_requests_client: FakeGitLabMergeRequestsHTTPClient):
@@ -219,5 +250,23 @@ def gitlab_http_client_config(monkeypatch: pytest.MonkeyPatch):
             api_url=HttpUrl("https://gitlab.com"),
             api_token=SecretStr("fake-token"),
         )
+    )
+    monkeypatch.setattr(settings, "vcs", fake_config)
+
+
+@pytest.fixture
+def gitlab_batch_http_client_config(monkeypatch: pytest.MonkeyPatch):
+    fake_config = GitLabVCSConfig(
+        provider=VCSProvider.GITLAB,
+        pipeline=GitLabPipelineConfig(
+            project_id="project-id",
+            merge_request_id="merge-request-id"
+        ),
+        http_client=GitLabHTTPClientConfig(
+            timeout=10,
+            api_url=HttpUrl("https://gitlab.com"),
+            api_token=SecretStr("fake-token"),
+        ),
+        batch_comments=True,
     )
     monkeypatch.setattr(settings, "vcs", fake_config)

--- a/ai_review/tests/fixtures/services/review/gateway/review_comment_gateway.py
+++ b/ai_review/tests/fixtures/services/review/gateway/review_comment_gateway.py
@@ -104,6 +104,9 @@ class FakeReviewCommentGateway(ReviewCommentGatewayProtocol):
     async def process_inline_comments(self, comments: InlineCommentListSchema) -> None:
         self.calls.append(("process_inline_comments", {"comments": comments}))
 
+    async def finalize(self) -> None:
+        self.calls.append(("finalize", {}))
+
 
 @pytest.fixture
 def fake_review_comment_gateway() -> FakeReviewCommentGateway:

--- a/ai_review/tests/fixtures/services/vcs.py
+++ b/ai_review/tests/fixtures/services/vcs.py
@@ -81,6 +81,22 @@ class FakeVCSClient(VCSClientProtocol):
         return self.responses.get("get_general_threads", [])
 
 
+class FakeBatchingVCSClient(FakeVCSClient):
+    """FakeVCSClient with the optional SupportsBatchedComments capability."""
+
+    async def publish_comments(self) -> None:
+        self.calls.append(("publish_comments", (), {}))
+        if error := self.responses.get("publish_comments_error"):
+            raise error
+
+        return self.responses.get("publish_comments_result", None)
+
+
 @pytest.fixture
 def fake_vcs_client() -> FakeVCSClient:
     return FakeVCSClient()
+
+
+@pytest.fixture
+def fake_batching_vcs_client() -> FakeBatchingVCSClient:
+    return FakeBatchingVCSClient()

--- a/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
+++ b/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
@@ -8,7 +8,7 @@ from ai_review.services.review.internal.summary.schema import SummaryCommentSche
 from ai_review.services.review.internal.summary_reply.schema import SummaryCommentReplySchema
 from ai_review.services.vcs.types import ReviewThreadSchema, ReviewCommentSchema, ThreadKind
 from ai_review.tests.fixtures.services.artifacts import FakeArtifactsService
-from ai_review.tests.fixtures.services.vcs import FakeVCSClient
+from ai_review.tests.fixtures.services.vcs import FakeVCSClient, FakeBatchingVCSClient
 
 
 # === INLINE THREADS ===
@@ -472,3 +472,46 @@ async def test_get_summary_comments_excludes_fallback_comments(
 
     assert len(result) == 1
     assert result[0].id == "10"
+
+
+# === FINALIZE ===
+
+@pytest.mark.asyncio
+async def test_finalize_publishes_batched_comments(
+        fake_batching_vcs_client: FakeBatchingVCSClient,
+        fake_artifacts_service: FakeArtifactsService,
+):
+    """Should publish batched comments when the VCS client supports batching."""
+    gateway = ReviewCommentGateway(vcs=fake_batching_vcs_client, artifacts=fake_artifacts_service)
+
+    await gateway.finalize()
+
+    assert any(call[0] == "publish_comments" for call in fake_batching_vcs_client.calls)
+
+
+@pytest.mark.asyncio
+async def test_finalize_skips_non_batching_vcs(
+        fake_vcs_client: FakeVCSClient,
+        review_comment_gateway: ReviewCommentGateway,
+):
+    """Should be a no-op for VCS clients without the batching capability."""
+    await review_comment_gateway.finalize()
+
+    assert fake_vcs_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_swallows_vcs_errors(
+        capsys: pytest.CaptureFixture,
+        fake_batching_vcs_client: FakeBatchingVCSClient,
+        fake_artifacts_service: FakeArtifactsService,
+):
+    """Should log and swallow errors from the VCS client."""
+    fake_batching_vcs_client.responses["publish_comments_error"] = RuntimeError("boom")
+    gateway = ReviewCommentGateway(vcs=fake_batching_vcs_client, artifacts=fake_artifacts_service)
+
+    await gateway.finalize()
+    output = capsys.readouterr().out
+
+    assert any(call[0] == "publish_comments" for call in fake_batching_vcs_client.calls)
+    assert "Failed to publish batched comments" in output

--- a/ai_review/tests/suites/services/review/gateway/test_review_dry_run_comment_gateway.py
+++ b/ai_review/tests/suites/services/review/gateway/test_review_dry_run_comment_gateway.py
@@ -8,7 +8,7 @@ from ai_review.services.review.internal.summary.schema import SummaryCommentSche
 from ai_review.services.review.internal.summary_reply.schema import SummaryCommentReplySchema
 from ai_review.services.vcs.types import ReviewCommentSchema
 from ai_review.tests.fixtures.services.artifacts import FakeArtifactsService
-from ai_review.tests.fixtures.services.vcs import FakeVCSClient
+from ai_review.tests.fixtures.services.vcs import FakeVCSClient, FakeBatchingVCSClient
 
 
 @pytest.mark.asyncio
@@ -186,3 +186,16 @@ async def test_clear_summary_comments_dry_run_logs_each_comment(
     assert "[dry-run] Would delete summary comment 11" in output
 
     assert not any(call[0].startswith("delete_") for call in fake_vcs_client.calls)
+
+
+@pytest.mark.asyncio
+async def test_finalize_does_not_touch_vcs(
+        fake_batching_vcs_client: FakeBatchingVCSClient,
+        fake_artifacts_service: FakeArtifactsService,
+):
+    """Dry run should not publish anything to the VCS, even with a batching client."""
+    gateway = ReviewDryRunCommentGateway(vcs=fake_batching_vcs_client, artifacts=fake_artifacts_service)
+
+    await gateway.finalize()
+
+    assert not any(call[0] == "publish_comments" for call in fake_batching_vcs_client.calls)

--- a/ai_review/tests/suites/services/review/runner/test_context.py
+++ b/ai_review/tests/suites/services/review/runner/test_context.py
@@ -57,6 +57,7 @@ async def test_run_skips_when_existing_comments(
     vcs_calls = [call[0] for call in fake_vcs_client.calls]
     assert vcs_calls == []
     assert not any(call[0] == "ask" for call in fake_review_direct_llm_gateway.calls)
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)
 
 
 @pytest.mark.asyncio
@@ -75,6 +76,7 @@ async def test_run_skips_when_no_changed_files(
     vcs_calls = [call[0] for call in fake_vcs_client.calls]
     assert "get_review_info" in vcs_calls
     assert any(call[0] == "apply_for_files" for call in fake_policy_service.calls)
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)
 
 
 @pytest.mark.asyncio
@@ -95,3 +97,17 @@ async def test_run_skips_when_no_comments_after_llm(
     assert any(call[0] == "ask" for call in fake_review_direct_llm_gateway.calls)
     assert any(call[0] == "apply_for_context_comments" for call in fake_policy_service.calls)
     assert not any(call[0] == "process_inline_comments" for call in fake_review_comment_gateway.calls)
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_finalize(
+        context_review_runner: ContextReviewRunner,
+        fake_review_comment_gateway: FakeReviewCommentGateway,
+):
+    """Finalization (batch publishing) happens at pipeline level, not inside the runner."""
+    fake_review_comment_gateway.responses["get_inline_comments"] = []
+
+    await context_review_runner.run()
+
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)

--- a/ai_review/tests/suites/services/review/runner/test_inline.py
+++ b/ai_review/tests/suites/services/review/runner/test_inline.py
@@ -102,3 +102,33 @@ async def test_process_file_skips_when_no_comments_after_llm(
     assert any(call[0] == "ask" for call in fake_review_direct_llm_gateway.calls)
     assert any(call[0] == "apply_for_inline_comments" for call in fake_policy_service.calls)
     assert not any(call[0] == "process_inline_comments" for call in fake_review_comment_gateway.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_finalize(
+        inline_review_runner: InlineReviewRunner,
+        fake_git_service: FakeGitService,
+        fake_review_comment_gateway: FakeReviewCommentGateway,
+):
+    """Finalization (batch publishing) happens at pipeline level, not inside the runner."""
+    fake_git_service.responses["get_diff_for_file"] = "FAKE_DIFF"
+    fake_review_comment_gateway.responses["get_inline_comments"] = []
+
+    await inline_review_runner.run()
+
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_finalize_when_skipping(
+        inline_review_runner: InlineReviewRunner,
+        fake_review_comment_gateway: FakeReviewCommentGateway,
+):
+    """Should not finalize when the review is skipped due to existing comments."""
+    fake_review_comment_gateway.responses["get_inline_comments"] = [
+        ReviewCommentSchema(id="1", body=f"{settings.review.inline_tag} existing")
+    ]
+
+    await inline_review_runner.run()
+
+    assert not any(call[0] == "finalize" for call in fake_review_comment_gateway.calls)

--- a/ai_review/tests/suites/services/review/test_service.py
+++ b/ai_review/tests/suites/services/review/test_service.py
@@ -7,6 +7,7 @@ from ai_review.services.review.gateway.review_direct_llm_gateway import ReviewDi
 from ai_review.services.review.gateway.review_dry_run_comment_gateway import ReviewDryRunCommentGateway
 from ai_review.services.review.service import ReviewService
 from ai_review.tests.fixtures.services.cost import FakeCostService
+from ai_review.tests.fixtures.services.review.gateway.review_comment_gateway import FakeReviewCommentGateway
 from ai_review.tests.fixtures.services.review.runner.context import FakeContextReviewRunner
 from ai_review.tests.fixtures.services.review.runner.inline import FakeInlineReviewRunner
 from ai_review.tests.fixtures.services.review.runner.inline_reply import FakeInlineReplyReviewRunner
@@ -127,3 +128,28 @@ def test_review_service_uses_default_gateway_when_agent_disabled(monkeypatch: py
     monkeypatch.setattr("ai_review.config.settings.agent.enabled", False)
     service = ReviewService()
     assert type(service.review_llm_gateway) is ReviewDirectLLMGateway
+
+
+@pytest.mark.asyncio
+async def test_context_manager_finalizes_gateway(review_service: ReviewService):
+    """Leaving the ReviewService context should finalize the comment gateway."""
+    fake_gateway = FakeReviewCommentGateway()
+    review_service.review_comment_gateway = fake_gateway
+
+    async with review_service:
+        assert not any(call[0] == "finalize" for call in fake_gateway.calls)
+
+    assert any(call[0] == "finalize" for call in fake_gateway.calls)
+
+
+@pytest.mark.asyncio
+async def test_context_manager_finalizes_gateway_on_error(review_service: ReviewService):
+    """Should finalize the comment gateway even when the pipeline raises."""
+    fake_gateway = FakeReviewCommentGateway()
+    review_service.review_comment_gateway = fake_gateway
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with review_service:
+            raise RuntimeError("boom")
+
+    assert any(call[0] == "finalize" for call in fake_gateway.calls)

--- a/ai_review/tests/suites/services/vcs/gitlab/test_client.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_client.py
@@ -1,7 +1,13 @@
 import pytest
 
 from ai_review.services.vcs.gitlab.client import GitLabVCSClient
-from ai_review.services.vcs.types import ReviewInfoSchema, ReviewCommentSchema, ReviewThreadSchema, ThreadKind
+from ai_review.services.vcs.types import (
+    ReviewInfoSchema,
+    ReviewCommentSchema,
+    ReviewThreadSchema,
+    ThreadKind,
+    SupportsBatchedComments,
+)
 from ai_review.tests.fixtures.clients.gitlab import FakeGitLabMergeRequestsHTTPClient
 
 
@@ -277,3 +283,141 @@ async def test_delete_inline_comment_calls_delete_discussion(
     assert call_args["note_id"] == str(note_id)
     assert call_args["project_id"] == "project-id"
     assert call_args["merge_request_id"] == "merge-request-id"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_inline_comment_creates_draft_note_when_batching(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should create a draft note instead of a discussion when batch_comments is enabled."""
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Batched comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "create_draft_note" in called_methods
+    assert "create_discussion" not in called_methods
+
+    calls = [
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_draft_note"
+    ]
+    assert len(calls) == 1
+    call_args = calls[0]
+
+    assert call_args["note"] == "Batched comment"
+    assert call_args["project_id"] == "project-id"
+    assert call_args["merge_request_id"] == "merge-request-id"
+    assert call_args["position"].new_path == "src/app.py"
+    assert call_args["position"].new_line == 12
+    assert gitlab_vcs_client.pending_comments == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config")
+async def test_create_inline_comment_creates_discussion_by_default(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should keep posting discussions when batch_comments is disabled (default)."""
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Immediate comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "create_discussion" in called_methods
+    assert "create_draft_note" not in called_methods
+    assert gitlab_vcs_client.pending_comments == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_publish_comments_bulk_publishes_pending_drafts(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should bulk publish once pending draft notes exist and reset the counter."""
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Comment A")
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=14, message="Comment B")
+
+    await gitlab_vcs_client.publish_comments()
+
+    calls = [
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "bulk_publish_draft_notes"
+    ]
+    assert len(calls) == 1
+    assert calls[0]["project_id"] == "project-id"
+    assert calls[0]["merge_request_id"] == "merge-request-id"
+    assert gitlab_vcs_client.pending_comments == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_publish_comments_noop_without_pending_drafts(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should not call the API when no draft notes were created."""
+    await gitlab_vcs_client.publish_comments()
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config")
+async def test_publish_comments_noop_when_batching_disabled(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should not call the API when batch_comments is disabled."""
+    await gitlab_vcs_client.publish_comments()
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_general_comment_creates_draft_note_when_batching(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should create a positionless draft note instead of a note when batch_comments is enabled."""
+    await gitlab_vcs_client.create_general_comment("Batched summary")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "create_draft_note" in called_methods
+    assert "create_note" not in called_methods
+
+    calls = [
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_draft_note"
+    ]
+    assert len(calls) == 1
+    assert calls[0]["note"] == "Batched summary"
+    assert calls[0]["position"] is None
+    assert gitlab_vcs_client.pending_comments == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_publish_comments_covers_inline_and_general_drafts(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should count inline and general drafts together and bulk publish once."""
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Inline")
+    await gitlab_vcs_client.create_general_comment("Summary")
+    assert gitlab_vcs_client.pending_comments == 2
+
+    await gitlab_vcs_client.publish_comments()
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods.count("bulk_publish_draft_notes") == 1
+    assert gitlab_vcs_client.pending_comments == 0
+
+
+@pytest.mark.usefixtures("gitlab_http_client_config")
+def test_gitlab_client_has_batching_capability(gitlab_vcs_client: GitLabVCSClient):
+    """GitLabVCSClient should expose the optional SupportsBatchedComments capability."""
+    assert isinstance(gitlab_vcs_client, SupportsBatchedComments)

--- a/docs/configs/.ai-review.json
+++ b/docs/configs/.ai-review.json
@@ -17,6 +17,7 @@
   },
   "vcs": {
     "provider": "GITLAB",
+    "batch_comments": false,
     "pipeline": {
       "project_id": "${CI_PROJECT_ID}",
       "merge_request_id": "${CI_MERGE_REQUEST_IID}"

--- a/docs/configs/.ai-review.yaml
+++ b/docs/configs/.ai-review.yaml
@@ -108,6 +108,14 @@ vcs:
   # Options: GITLAB | GITHUB | BITBUCKET_CLOUD | BITBUCKET_SERVER | AZURE_DEVOPS | GITEA
   provider: GITLAB
 
+  # --- GitLab only (requires GitLab 15.10+) ---
+  # Part of the GitLab provider config; other providers ignore this option.
+  # Post inline comments and the summary comment as draft notes and publish them in one batch
+  # ("Start a review" -> "Submit review"), so reviewers get a single
+  # email notification for the entire review.
+  # Default: false
+  batch_comments: false
+
   # Pipeline/MR/PR context.
   pipeline:
     # --- GitLab ---

--- a/docs/configs/.env.example
+++ b/docs/configs/.env.example
@@ -96,6 +96,10 @@ VCS__PAGINATION__MAX_PAGES=5
 # --- GitLab ---
 VCS__PIPELINE__PROJECT_ID=${CI_PROJECT_ID}
 VCS__PIPELINE__MERGE_REQUEST_ID=${CI_MERGE_REQUEST_IID}
+# GitLab only (requires GitLab 15.10+; ignored by all other providers):
+# post inline comments and the summary comment as draft notes and publish them in one batch,
+# so reviewers get a single email notification for the entire review. Default: false
+VCS__BATCH_COMMENTS=false
 
 VCS__HTTP_CLIENT__VERIFY=true
 VCS__HTTP_CLIENT__TIMEOUT=120


### PR DESCRIPTION
Closes #105

## What

Adds an opt-in GitLab-only setting `batch_comments` on the GitLab VCS config
(env: `VCS__BATCH_COMMENTS`, default `false`).
When enabled, the review's comments are created as **draft notes**
(the API behind GitLab's "Start a review") and published with a single
`draft_notes/bulk_publish` call at the end of the pipeline —
so a full `run` (inline review + summary) produces **one** email notification
for the entire review, with the summary comment appearing after the inline
comments, exactly like the UI's "Submit review" summary box.

## How

- New Draft Notes endpoints in the GitLab HTTP client (`create_draft_note`, `bulk_publish_draft_notes`);
  draft payloads are serialized with `exclude_none=True` (a positionless draft — the summary —
  must omit `position` entirely, and omitted optional keys match the docs' examples).
- The draft/publish lifecycle is internal to `GitLabVCSClient`:
  `create_inline_comment` / `create_general_comment` decide draft vs. direct based on the flag
  (drafting covers inline comments, the summary, summary replies, and inline-fallback comments).
  The shared `VCSClientProtocol` is unchanged and the other providers are untouched;
  GitLab with the flag off is byte-for-byte unchanged.
- A small `@runtime_checkable SupportsBatchedComments` capability protocol exposes
  `publish_comments()`. A future provider-specific batching mechanism
  (e.g. GitHub's pending-reviews API) implements the same capability
  without adding anything to the shared interface.
- `ReviewService` is an async context manager and the CLI commands run inside it.
  On exit the comment gateway finalizes the review and bulk-publishes the pending batch
  only when the active client actually has the capability — a no-op for every other provider.
  Finalization also runs when the pipeline raises, so a failed run publishes the
  comments it already drafted instead of leaving invisible drafts behind.
  Dry-run mode never touches the VCS.
- On partial failure the existing behavior is preserved: failed comments are logged
  (and fall back to a general comment if `inline_comment_fallback` is on — the fallback
  joins the same batch), successfully created drafts are still published, and the run completes.
- Tests at every layer (HTTP fake, VCS client, gateway, service, runners, CLI);
  full suite passes (735 tests), each commit passes individually.

## Notes / limitations

- Requires GitLab 15.10+ (Draft Notes API). The feature is off by default, so older instances are unaffected.
- In batch mode the `emit_*_review_complete` hooks fire before the comments become visible,
  since publishing happens at the end of the pipeline.
- `bulk_publish` publishes **all** pending drafts of the token user — including any drafts
  a human might have left while logged in as the bot account.
- `clear-inline` / `clear-summary` do not delete pending drafts (they are not notes/discussions yet).
- Smoke-tested successfully against a private GitLab instance (7 inline comments + 1 summary,
  delivered in a single email). The drafting/publishing wire calls are unchanged since that test;
  the rework only moved where publishing is triggered.
- Possible follow-ups: batching inline replies via `in_reply_to_discussion_id`,
  clearing/adopting stale drafts at review start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
