### PR TITLE
fix(gitlab): recover from a failed draft-note bulk publish

### DIFF
--- a/ai_review/clients/gitlab/mr/client.py
+++ b/ai_review/clients/gitlab/mr/client.py
@@ -29,6 +29,7 @@ from ai_review.config import settings
 from ai_review.libs.http.client import HTTPClient
 from ai_review.libs.http.handlers import handle_http_error, HTTPClientError
 from ai_review.libs.http.paginate import paginate
+from ai_review.libs.http.transports.retry import NO_RETRY
 
 
 class GitLabMergeRequestsHTTPClientError(HTTPClientError):
@@ -146,8 +147,12 @@ class GitLabMergeRequestsHTTPClient(HTTPClient, GitLabMergeRequestsHTTPClientPro
 
     @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
     async def bulk_publish_draft_notes_api(self, project_id: str, merge_request_id: str) -> Response:
+        # Not idempotent: GitLab publishes draft notes one by one without a
+        # surrounding transaction, so a 500 can mean "some notes were published".
+        # Retrying would publish more of them and duplicate the ones that landed.
         return await self.post(
-            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes/bulk_publish"
+            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes/bulk_publish",
+            extensions=NO_RETRY,
         )
 
     async def get_changes(self, project_id: str, merge_request_id: str) -> GitLabGetMRChangesResponseSchema:

--- a/ai_review/clients/gitlab/mr/client.py
+++ b/ai_review/clients/gitlab/mr/client.py
@@ -13,6 +13,8 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
 from ai_review.clients.gitlab.mr.schema.draft_notes import (
     GitLabDraftNoteSchema,
     GitLabCreateMRDraftNoteRequestSchema,
+    GitLabGetMRDraftNotesQuerySchema,
+    GitLabGetMRDraftNotesResponseSchema,
 )
 from ai_review.clients.gitlab.mr.schema.notes import (
     GitLabNoteSchema,
@@ -117,6 +119,29 @@ class GitLabMergeRequestsHTTPClient(HTTPClient, GitLabMergeRequestsHTTPClientPro
         return await self.post(
             f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes",
             json=request.model_dump(exclude_none=True),
+        )
+
+    @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
+    async def get_draft_notes_api(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            query: GitLabGetMRDraftNotesQuerySchema,
+    ) -> Response:
+        return await self.get(
+            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes",
+            query=QueryParams(**query.model_dump())
+        )
+
+    @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
+    async def delete_draft_note_api(
+            self,
+            project_id: str,
+            merge_request_id: str,
+            draft_note_id: str,
+    ) -> Response:
+        return await self.delete(
+            f"/api/v4/projects/{project_id}/merge_requests/{merge_request_id}/draft_notes/{draft_note_id}"
         )
 
     @handle_http_error(client="GitLabMergeRequestsHTTPClient", exception=GitLabMergeRequestsHTTPClientError)
@@ -229,6 +254,30 @@ class GitLabMergeRequestsHTTPClient(HTTPClient, GitLabMergeRequestsHTTPClientPro
             merge_request_id=merge_request_id,
         )
         return GitLabDraftNoteSchema.model_validate_json(response.text)
+
+    async def get_draft_notes(
+            self,
+            project_id: str,
+            merge_request_id: str
+    ) -> GitLabGetMRDraftNotesResponseSchema:
+        async def fetch_page(page: int) -> Response:
+            query = GitLabGetMRDraftNotesQuerySchema(page=page, per_page=settings.vcs.pagination.per_page)
+            return await self.get_draft_notes_api(project_id, merge_request_id, query)
+
+        def extract_items(response: Response) -> list[GitLabDraftNoteSchema]:
+            result = GitLabGetMRDraftNotesResponseSchema.model_validate_json(response.text)
+            return result.root
+
+        items = await paginate(
+            max_pages=settings.vcs.pagination.max_pages,
+            fetch_page=fetch_page,
+            extract_items=extract_items,
+            has_next_page=gitlab_has_next_page
+        )
+        return GitLabGetMRDraftNotesResponseSchema(root=items)
+
+    async def delete_draft_note(self, project_id: str, merge_request_id: str, draft_note_id: str) -> None:
+        await self.delete_draft_note_api(project_id, merge_request_id, draft_note_id)
 
     async def bulk_publish_draft_notes(self, project_id: str, merge_request_id: str) -> None:
         await self.bulk_publish_draft_notes_api(project_id, merge_request_id)

--- a/ai_review/clients/gitlab/mr/schema/draft_notes.py
+++ b/ai_review/clients/gitlab/mr/schema/draft_notes.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 
 from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
 
@@ -12,3 +12,12 @@ class GitLabDraftNoteSchema(BaseModel):
 class GitLabCreateMRDraftNoteRequestSchema(BaseModel):
     note: str
     position: GitLabPositionSchema | None = None
+
+
+class GitLabGetMRDraftNotesQuerySchema(BaseModel):
+    page: int = 1
+    per_page: int = 100
+
+
+class GitLabGetMRDraftNotesResponseSchema(RootModel[list[GitLabDraftNoteSchema]]):
+    root: list[GitLabDraftNoteSchema]

--- a/ai_review/clients/gitlab/mr/types.py
+++ b/ai_review/clients/gitlab/mr/types.py
@@ -10,6 +10,7 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
 from ai_review.clients.gitlab.mr.schema.draft_notes import (
     GitLabDraftNoteSchema,
     GitLabCreateMRDraftNoteRequestSchema,
+    GitLabGetMRDraftNotesResponseSchema,
 )
 from ai_review.clients.gitlab.mr.schema.notes import GitLabGetMRNotesResponseSchema, GitLabCreateMRNoteResponseSchema
 
@@ -55,5 +56,13 @@ class GitLabMergeRequestsHTTPClientProtocol(Protocol):
             merge_request_id: str,
             request: GitLabCreateMRDraftNoteRequestSchema,
     ) -> GitLabDraftNoteSchema: ...
+
+    async def get_draft_notes(
+            self,
+            project_id: str,
+            merge_request_id: str
+    ) -> GitLabGetMRDraftNotesResponseSchema: ...
+
+    async def delete_draft_note(self, project_id: str, merge_request_id: str, draft_note_id: str) -> None: ...
 
     async def bulk_publish_draft_notes(self, project_id: str, merge_request_id: str) -> None: ...

--- a/ai_review/libs/http/client.py
+++ b/ai_review/libs/http/client.py
@@ -21,8 +21,16 @@ class HTTPClient:
             query: QueryParams | None = None,
             headers: HeaderTypes | None = None,
             content: RequestContent | None = None,
+            extensions: dict[str, Any] | None = None,
     ) -> Response:
-        return await self.client.post(url=url, json=json, params=query, headers=headers, content=content)
+        return await self.client.post(
+            url=url,
+            json=json,
+            params=query,
+            headers=headers,
+            content=content,
+            extensions=extensions,
+        )
 
     async def patch(self, url: str, json: Any | None = None, query: QueryParams | None = None) -> Response:
         return await self.client.patch(url=url, json=json, params=query)

--- a/ai_review/libs/http/transports/retry.py
+++ b/ai_review/libs/http/transports/retry.py
@@ -7,6 +7,9 @@ from httpx import Request, Response, AsyncBaseTransport
 if TYPE_CHECKING:
     from loguru import Logger
 
+NO_RETRY_EXTENSION: str = "no_retry"
+NO_RETRY: dict[str, bool] = {NO_RETRY_EXTENSION: True}
+
 
 class RetryTransport(AsyncBaseTransport):
     def __init__(
@@ -29,6 +32,9 @@ class RetryTransport(AsyncBaseTransport):
         self.retry_status_codes = retry_status_codes
 
     async def handle_async_request(self, request: Request) -> Response:
+        if request.extensions.get(NO_RETRY_EXTENSION):
+            return await self.transport.handle_async_request(request)
+
         last_response: Response | None = None
         for attempt in range(self.max_retries):
             last_response = await self.transport.handle_async_request(request)

--- a/ai_review/services/vcs/gitlab/client.py
+++ b/ai_review/services/vcs/gitlab/client.py
@@ -289,7 +289,11 @@ class GitLabVCSClient(VCSClientProtocol):
             self.pending_comments = 0
             logger.info(f"Published draft comments in {self.merge_request_ref}")
         except Exception as error:
-            logger.exception(f"Failed to publish draft comments in {self.merge_request_ref}: {error}")
+            logger.exception(
+                f"Failed to publish draft comments in {self.merge_request_ref}: {error}. "
+                f"GitLab may have published part of the batch; the remaining drafts stay pending "
+                f"and the next run discards them"
+            )
             raise
 
     async def delete_general_comment(self, comment_id: int | str) -> None:

--- a/ai_review/services/vcs/gitlab/client.py
+++ b/ai_review/services/vcs/gitlab/client.py
@@ -1,8 +1,11 @@
+import asyncio
+
 from ai_review.clients.gitlab.client import get_gitlab_http_client
 from ai_review.clients.gitlab.mr.schema.discussions import GitLabCreateMRDiscussionRequestSchema
 from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabCreateMRDraftNoteRequestSchema
 from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
 from ai_review.config import settings
+from ai_review.libs.asynchronous.gather import bounded_gather
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.gitlab.adapter import get_user_from_gitlab_user, get_review_comment_from_gitlab_note
 from ai_review.services.vcs.types import (
@@ -25,6 +28,8 @@ class GitLabVCSClient(VCSClientProtocol):
         self.merge_request_id = settings.vcs.pipeline.merge_request_id
         self.merge_request_ref = f"project_id={self.project_id} merge_request_id={self.merge_request_id}"
         self.pending_comments = 0
+        self.discarded_stale_drafts = False
+        self.discard_stale_drafts_lock = asyncio.Lock()
 
     # --- Review info ---
     async def get_review_info(self) -> ReviewInfoSchema:
@@ -128,7 +133,66 @@ class GitLabVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in {self.merge_request_ref}: {error}")
             raise
 
+    async def discard_stale_draft_comments(self) -> None:
+        """Delete draft notes left behind by an earlier run or a concurrent job, once per process.
+
+        GitLab's bulk publish endpoint takes no draft-note selector: it publishes every
+        draft note the token user has on the merge request, regardless of which run staged
+        it. Leftover drafts would therefore be posted retroactively, with diff refs that no
+        longer resolve. GitLab scopes the draft-note endpoints to
+        ``authored_by(current_user)``, so this only ever sees ai-review's own pending notes,
+        never a human reviewer's staged review.
+        """
+        # Guards against a future await landing between the flag check and the flag set below; today there is none.
+        async with self.discard_stale_drafts_lock:
+            if self.discarded_stale_drafts:
+                return
+
+            self.discarded_stale_drafts = True
+
+            try:
+                response = await self.http_client.mr.get_draft_notes(
+                    project_id=self.project_id,
+                    merge_request_id=self.merge_request_id,
+                )
+            except Exception as error:
+                logger.exception(
+                    f"Failed to look up stale draft comments in {self.merge_request_ref}: {error}. "
+                    f"Publishing may post leftovers from an earlier run"
+                )
+                return
+
+            if not response.root:
+                logger.debug(f"No stale draft comments in {self.merge_request_ref}")
+                return
+
+            logger.debug(
+                f"Discarding stale draft notes in {self.merge_request_ref}: "
+                f"{[(draft_note.id, draft_note.note) for draft_note in response.root]}"
+            )
+            logger.warning(
+                f"Discarding {len(response.root)} pending draft comments from a previous run "
+                f"or a concurrent job in {self.merge_request_ref}"
+            )
+            results = await bounded_gather([
+                self.http_client.mr.delete_draft_note(
+                    project_id=self.project_id,
+                    merge_request_id=self.merge_request_id,
+                    draft_note_id=str(draft_note.id),
+                )
+                for draft_note in response.root
+            ])
+
+            failures = [result for result in results if isinstance(result, Exception)]
+            if failures:
+                logger.error(
+                    f"Failed to discard {len(failures)}/{len(response.root)} stale draft comments "
+                    f"in {self.merge_request_ref}"
+                )
+
     async def create_draft_general_comment(self, message: str) -> None:
+        await self.discard_stale_draft_comments()
+
         try:
             logger.info(f"Adding draft general comment to {self.merge_request_ref}: {message}")
             request = GitLabCreateMRDraftNoteRequestSchema(note=message)
@@ -178,6 +242,8 @@ class GitLabVCSClient(VCSClientProtocol):
             raise
 
     async def create_draft_inline_comment(self, file: str, line: int, message: str) -> None:
+        await self.discard_stale_draft_comments()
+
         try:
             logger.info(f"Adding draft inline comment in {self.merge_request_ref} at {file}:{line}: {message}")
 

--- a/ai_review/tests/fixtures/clients/gitlab.py
+++ b/ai_review/tests/fixtures/clients/gitlab.py
@@ -17,6 +17,7 @@ from ai_review.clients.gitlab.mr.schema.discussions import (
 from ai_review.clients.gitlab.mr.schema.draft_notes import (
     GitLabDraftNoteSchema,
     GitLabCreateMRDraftNoteRequestSchema,
+    GitLabGetMRDraftNotesResponseSchema,
 )
 from ai_review.clients.gitlab.mr.schema.notes import (
     GitLabNoteSchema,
@@ -35,6 +36,8 @@ from ai_review.services.vcs.gitlab.client import GitLabVCSClient
 class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
     def __init__(self):
         self.calls: list[tuple[str, dict]] = []
+        self.draft_notes: list[GitLabDraftNoteSchema] = []
+        self.get_draft_notes_error: Exception | None = None
 
     async def get_changes(self, project_id: str, merge_request_id: str) -> GitLabGetMRChangesResponseSchema:
         self.calls.append(("get_changes", {"project_id": project_id, "merge_request_id": merge_request_id}))
@@ -203,6 +206,30 @@ class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
             (
                 "bulk_publish_draft_notes",
                 {"project_id": project_id, "merge_request_id": merge_request_id},
+            )
+        )
+
+    async def get_draft_notes(
+            self,
+            project_id: str,
+            merge_request_id: str
+    ) -> GitLabGetMRDraftNotesResponseSchema:
+        self.calls.append(("get_draft_notes", {"project_id": project_id, "merge_request_id": merge_request_id}))
+
+        if self.get_draft_notes_error:
+            raise self.get_draft_notes_error
+
+        return GitLabGetMRDraftNotesResponseSchema(root=list(self.draft_notes))
+
+    async def delete_draft_note(self, project_id: str, merge_request_id: str, draft_note_id: str) -> None:
+        self.calls.append(
+            (
+                "delete_draft_note",
+                {
+                    "project_id": project_id,
+                    "merge_request_id": merge_request_id,
+                    "draft_note_id": draft_note_id,
+                },
             )
         )
 

--- a/ai_review/tests/suites/clients/gitlab/test_client.py
+++ b/ai_review/tests/suites/clients/gitlab/test_client.py
@@ -1,8 +1,10 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, MockTransport, Request, Response
 
 from ai_review.clients.gitlab.client import get_gitlab_http_client, GitLabHTTPClient
 from ai_review.clients.gitlab.mr.client import GitLabMergeRequestsHTTPClient
+from ai_review.clients.gitlab.mr.schema.notes import GitLabCreateMRNoteRequestSchema
+from ai_review.libs.http.transports.retry import NO_RETRY_EXTENSION
 
 
 @pytest.mark.usefixtures("gitlab_http_client_config")
@@ -12,3 +14,37 @@ def test_get_gitlab_http_client_builds_ok():
     assert isinstance(gitlab_http_client, GitLabHTTPClient)
     assert isinstance(gitlab_http_client.mr, GitLabMergeRequestsHTTPClient)
     assert isinstance(gitlab_http_client.mr.client, AsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_bulk_publish_draft_notes_api_opts_out_of_retries_unlike_other_endpoints() -> None:
+    """The bulk-publish request must carry the retry opt-out; other endpoints must not.
+
+    Every GitLab test elsewhere goes through the fake client and bypasses HTTP, so this
+    is the only test that would fail if `extensions=NO_RETRY` were removed from
+    `bulk_publish_draft_notes_api`, or if the opt-out leaked into the shared `post()`
+    default and started applying to every endpoint.
+    """
+    captured: Request | None = None
+
+    async def handler(request: Request) -> Response:
+        nonlocal captured
+        captured = request
+        return Response(status_code=200, request=request, json={})
+
+    async with AsyncClient(
+            base_url="https://gitlab.test",
+            transport=MockTransport(handler),
+    ) as http_client:
+        gitlab_mr_client = GitLabMergeRequestsHTTPClient(client=http_client)
+
+        await gitlab_mr_client.bulk_publish_draft_notes_api(project_id="1", merge_request_id="2")
+        assert captured is not None
+        assert captured.extensions.get(NO_RETRY_EXTENSION) is True
+
+        await gitlab_mr_client.create_note_api(
+            project_id="1",
+            merge_request_id="2",
+            request=GitLabCreateMRNoteRequestSchema(body="hello"),
+        )
+        assert not captured.extensions.get(NO_RETRY_EXTENSION)

--- a/ai_review/tests/suites/libs/http/transports/test_retry.py
+++ b/ai_review/tests/suites/libs/http/transports/test_retry.py
@@ -1,0 +1,63 @@
+import httpx
+import pytest
+
+from ai_review.libs.http.transports.retry import NO_RETRY, RetryTransport
+from ai_review.libs.logger import get_logger
+
+
+class CountingTransport(httpx.AsyncBaseTransport):
+    """Inner transport that always answers with the same status and counts attempts."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.attempts = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.attempts += 1
+        return httpx.Response(self.status_code, request=request)
+
+
+def build_retry_transport(inner: CountingTransport) -> RetryTransport:
+    return RetryTransport(
+        logger=get_logger("TEST_RETRY_TRANSPORT"),
+        transport=inner,
+        max_retries=3,
+        retry_delay=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_transport_retries_server_errors():
+    """Should exhaust max_retries when the server keeps answering 500."""
+    inner = CountingTransport(status_code=500)
+    transport = build_retry_transport(inner)
+
+    response = await transport.handle_async_request(httpx.Request("POST", "https://gitlab.test/api"))
+
+    assert response.status_code == 500
+    assert inner.attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_transport_does_not_retry_when_opted_out():
+    """Should make a single attempt for a request marked as non-idempotent."""
+    inner = CountingTransport(status_code=500)
+    transport = build_retry_transport(inner)
+    request = httpx.Request("POST", "https://gitlab.test/api", extensions=NO_RETRY)
+
+    response = await transport.handle_async_request(request)
+
+    assert response.status_code == 500
+    assert inner.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_transport_returns_success_without_retrying():
+    """Should return a successful response on the first attempt."""
+    inner = CountingTransport(status_code=200)
+    transport = build_retry_transport(inner)
+
+    response = await transport.handle_async_request(httpx.Request("GET", "https://gitlab.test/api"))
+
+    assert response.status_code == 200
+    assert inner.attempts == 1

--- a/ai_review/tests/suites/services/vcs/gitlab/test_client.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_client.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 
+from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabDraftNoteSchema
 from ai_review.services.vcs.gitlab.client import GitLabVCSClient
 from ai_review.services.vcs.types import (
     ReviewInfoSchema,
@@ -421,3 +424,118 @@ async def test_publish_comments_covers_inline_and_general_drafts(
 def test_gitlab_client_has_batching_capability(gitlab_vcs_client: GitLabVCSClient):
     """GitLabVCSClient should expose the optional SupportsBatchedComments capability."""
     assert isinstance(gitlab_vcs_client, SupportsBatchedComments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_inline_comment_discards_stale_drafts_before_staging(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should delete leftover draft notes before creating the first new one."""
+    fake_gitlab_merge_requests_http_client.draft_notes = [
+        GitLabDraftNoteSchema(id=901, note="stale inline #ai-review-inline"),
+        GitLabDraftNoteSchema(id=902, note="stale summary #ai-review-summary"),
+    ]
+
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Fresh comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods.index("get_draft_notes") < called_methods.index("create_draft_note")
+
+    deleted = sorted(
+        args["draft_note_id"] for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "delete_draft_note"
+    )
+    assert deleted == ["901", "902"]
+    assert gitlab_vcs_client.pending_comments == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_concurrent_draft_comments_discard_stale_drafts_once(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should discard stale drafts exactly once even when comments are staged concurrently."""
+    fake_gitlab_merge_requests_http_client.draft_notes = [
+        GitLabDraftNoteSchema(id=901, note="stale inline #ai-review-inline"),
+    ]
+
+    await asyncio.gather(
+        gitlab_vcs_client.create_inline_comment(file="a.py", line=1, message="A"),
+        gitlab_vcs_client.create_inline_comment(file="b.py", line=2, message="B"),
+        gitlab_vcs_client.create_general_comment("C"),
+    )
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods.count("get_draft_notes") == 1
+    assert called_methods.count("delete_draft_note") == 1
+    assert called_methods.count("create_draft_note") == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config")
+async def test_create_inline_comment_does_not_discard_drafts_without_batching(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should never touch draft notes when batch_comments is disabled."""
+    fake_gitlab_merge_requests_http_client.draft_notes = [
+        GitLabDraftNoteSchema(id=901, note="stale inline #ai-review-inline"),
+    ]
+
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Immediate comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "get_draft_notes" not in called_methods
+    assert "delete_draft_note" not in called_methods
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_inline_comment_deletes_nothing_when_no_stale_drafts(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should look for stale drafts but delete nothing when the list is empty."""
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Fresh comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "get_draft_notes" in called_methods
+    assert "delete_draft_note" not in called_methods
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_inline_comment_stages_note_when_discard_fails(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should keep staging comments when the stale-draft lookup fails."""
+    fake_gitlab_merge_requests_http_client.get_draft_notes_error = RuntimeError("gitlab is down")
+
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="Fresh comment")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert "create_draft_note" in called_methods
+    assert gitlab_vcs_client.pending_comments == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config")
+async def test_create_inline_comment_does_not_retry_purge_within_run_after_failure(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should not retry the stale-draft lookup within a run once it has failed, even
+    though staging keeps succeeding for every comment after that."""
+    fake_gitlab_merge_requests_http_client.get_draft_notes_error = RuntimeError("gitlab is down")
+
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=12, message="First")
+    await gitlab_vcs_client.create_inline_comment(file="src/app.py", line=14, message="Second")
+
+    called_methods = [name for name, _ in fake_gitlab_merge_requests_http_client.calls]
+    assert called_methods.count("get_draft_notes") == 1
+    assert called_methods.count("create_draft_note") == 2
+    assert gitlab_vcs_client.pending_comments == 2


### PR DESCRIPTION
## Problem

With `VCS__BATCH_COMMENTS` enabled (#111), a failed `bulk_publish` puts the merge request into a state that never recovers on its own.

Observed on a real merge request, repeating on every subsequent run:

```
ERROR | GITLAB_HTTP_CLIENT | All 5 attempts failed for POST
  .../merge_requests/25/draft_notes/bulk_publish (last status=500)
```

GitLab's side:

```json
{
  "exception.class": "DiffNote::NoteDiffFileCreationError",
  "exception.message": "Failed to find diff line for: redacted.yml, old_line: , new_line: 50",
  "exception.backtrace": ["app/models/diff_note.rb:75:in `create_diff_file'", "…_run_commit_callbacks…"]
}
```

Three facts about the endpoint combine into a loop:

1. `POST /draft_notes` does not validate the diff position.
   Resolution happens at publish time,
   so staging returns 200 and only `bulk_publish` fails.
2. `bulk_publish` takes no draft-note selector.
   It publishes *every* draft note the token user has on the merge request,
   not just the ones this run staged.
3. `finalize` swallows the failure, so the drafts survive.

The next run stages fresh drafts and calls `bulk_publish` again,
which again targets the leftovers —
whose `base_sha` / `head_sha` / `start_sha` are obsolete by then,
certainly after a force-push.
That 500s again, indefinitely, and the merge request accumulates drafts on every attempt.

Two amplifiers made it worse.
The breaking exception is raised from an `after_commit` callback,
and `DraftNotes::PublishService` iterates with `filter_map` without a surrounding transaction —
so a 500 can mean *some notes were already published*.
Meanwhile `RetryTransport` retried `INTERNAL_SERVER_ERROR` five times,
publishing a few more notes on each attempt and duplicating the ones that had landed.

## Changes

**`feat(gitlab): discard leftover draft notes before staging a new batch`**

Delete the token user's pending draft notes once per process,
before the first note of a run is staged.
This cuts the loop: a run that publishes nothing leaves no comments,
so the next run's skip-checks are empty, the review runs,
and staging purges the stale drafts before `bulk_publish` sees them.

Scoped safely by GitLab itself:
`lib/api/draft_notes.rb` resolves the list endpoint through
`merge_request(params: params).draft_notes.authored_by(current_user)`,
and the docs state "Before publishing, draft notes are visible only to the author".
A human reviewer's staged review is therefore out of reach —
the token user cannot even enumerate it.

`create_draft_inline_comment` runs under `bounded_gather`,
so the purge is guarded by an `asyncio.Lock` with the done-flag set *inside* the lock
before any await.
Without that ordering a second purge could delete notes the first caller had just staged.

**`fix(http): do not retry the non-idempotent draft-note bulk publish`**

Adds a generic per-request retry opt-out to `RetryTransport`
(`NO_RETRY`, read as "this request is not idempotent")
and an `extensions` passthrough on `HTTPClient.post`,
then uses it for `bulk_publish` only.
The failure now surfaces once, carrying GitLab's own message,
instead of five times carrying none of it.

## Scoping

Kept inside the GitLab client and the GitLab HTTP client, per the constraints from #111:

- Nothing added to `VCSClientProtocol` or `SupportsBatchedComments`.
- No new configuration keys — the purge is implied by the existing `batch_comments`
  and is reached only through the `create_draft_*` methods.
- No GitLab concept in `ai_review/libs/http/`; the opt-out is a generic capability.
- Cost to providers that do not use this: one `dict.get` per request in the transport,
  and one defaulted keyword on `HTTPClient.post`.
  Verified that all existing `.post(` call sites pass by keyword,
  and that every `RetryTransport` consumer keeps its prior 5xx behavior.

## Testing

767 passing. New coverage:

- leftover drafts are deleted before the first note is staged
- the purge runs exactly once across concurrent inline creates
- it never runs with batching disabled
- an empty list deletes nothing
- a failed lookup still stages the comments, and is not retried within the run
- the transport retries 5xx normally, and makes a single attempt when opted out
- an `httpx.MockTransport` test asserts the real outgoing `bulk_publish` request carries the
  opt-out, with a companion assertion that another endpoint does not —
  so the test also fails if the opt-out ever moves to the shared `post()` default

## Deliberately not included

- **Per-draft publish fallback.**
  `PUT .../draft_notes/:id/publish` would let a single bad position fail alone
  while the rest of the review lands.
  That is the complete fix, but partial-publish semantics need their own investigation.
  This change is the prerequisite: the failure is now single-shot, self-healing across runs,
  and diagnosable from GitLab's own error message.
- **Validating diff positions before staging.**
  Prevents the failure rather than recovering from it,
  but duplicates GitLab's position resolution.
