### PR TITLE
fix(review): clear-summary leaves inline-fallback comments behind

### DIFF
--- a/ai_review/services/review/gateway/review_comment_gateway.py
+++ b/ai_review/services/review/gateway/review_comment_gateway.py
@@ -59,6 +59,24 @@ class ReviewCommentGateway(ReviewCommentGatewayProtocol):
         logger.info(f"Detected {len(summary_comments)}/{len(comments)} AI summary comments")
         return summary_comments
 
+    async def get_clearable_summary_comments(self) -> list[ReviewCommentSchema]:
+        """General comments that clear-summary removes.
+
+        Wider than get_summary_comments: it also matches the inline-fallback tag, so a
+        comment ai-review posted because a diff position was rejected is cleared too.
+        get_summary_comments must stay narrow — SummaryReviewRunner uses it to decide
+        whether a summary already exists, and a leftover fallback comment must not
+        suppress the summary review.
+        """
+        tags = (settings.review.summary_tag, settings.review.inline_fallback_tag)
+        general_comments = await self.vcs.get_general_comments()
+        comments = [
+            comment for comment in general_comments
+            if any(tag in comment.body for tag in tags)
+        ]
+        logger.info(f"Detected {len(comments)}/{len(general_comments)} clearable AI general comments")
+        return comments
+
     async def process_inline_reply(self, thread_id: str, reply: InlineCommentReplySchema) -> None:
         try:
             await hook.emit_inline_comment_reply_start(reply)
@@ -158,7 +176,7 @@ class ReviewCommentGateway(ReviewCommentGatewayProtocol):
         await hook.emit_clear_summary_comments_start()
 
         try:
-            comments = await self.get_summary_comments()
+            comments = await self.get_clearable_summary_comments()
             if not comments:
                 logger.info("No AI summary comments to clear")
                 await hook.emit_clear_summary_comments_complete(comments=comments)

--- a/ai_review/services/review/gateway/review_dry_run_comment_gateway.py
+++ b/ai_review/services/review/gateway/review_dry_run_comment_gateway.py
@@ -71,7 +71,7 @@ class ReviewDryRunCommentGateway(ReviewCommentGateway):
     async def clear_summary_comments(self) -> None:
         await hook.emit_clear_summary_comments_start()
 
-        comments = await self.get_summary_comments()
+        comments = await self.get_clearable_summary_comments()
         if not comments:
             logger.info("[dry-run] No AI summary comments to clear")
             await hook.emit_clear_summary_comments_complete(comments=comments)

--- a/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
+++ b/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
@@ -521,6 +521,43 @@ async def test_get_summary_comments_excludes_fallback_comments(
     assert result[0].id == "10"
 
 
+@pytest.mark.asyncio
+async def test_clear_summary_comments_deletes_inline_fallback_comments(
+        fake_vcs_client: FakeVCSClient,
+        review_comment_gateway: ReviewCommentGateway,
+):
+    """Should delete inline-fallback general comments alongside the summary comments."""
+    fake_vcs_client.responses["get_general_comments"] = [
+        ReviewCommentSchema(id="10", body=f"{settings.review.summary_tag} summary"),
+        ReviewCommentSchema(id="11", body=f"{settings.review.inline_fallback_tag} fallback"),
+        ReviewCommentSchema(id="12", body="a human wrote this"),
+    ]
+
+    await review_comment_gateway.clear_summary_comments()
+
+    deleted = [call for call in fake_vcs_client.calls if call[0] == "delete_general_comment"]
+    assert {call[1][0] for call in deleted} == {"10", "11"}
+
+
+@pytest.mark.asyncio
+async def test_get_summary_comments_ignores_inline_fallback_comments(
+        fake_vcs_client: FakeVCSClient,
+        review_comment_gateway: ReviewCommentGateway,
+):
+    """Should keep the summary skip-check blind to fallback comments.
+
+    SummaryReviewRunner skips the summary review when this returns anything, so a
+    leftover fallback comment must not suppress the summary.
+    """
+    fake_vcs_client.responses["get_general_comments"] = [
+        ReviewCommentSchema(id="11", body=f"{settings.review.inline_fallback_tag} fallback"),
+    ]
+
+    comments = await review_comment_gateway.get_summary_comments()
+
+    assert comments == []
+
+
 # === FINALIZE ===
 
 @pytest.mark.asyncio

--- a/ai_review/tests/suites/services/review/gateway/test_review_dry_run_comment_gateway.py
+++ b/ai_review/tests/suites/services/review/gateway/test_review_dry_run_comment_gateway.py
@@ -189,6 +189,30 @@ async def test_clear_summary_comments_dry_run_logs_each_comment(
 
 
 @pytest.mark.asyncio
+async def test_clear_summary_comments_dry_run_includes_inline_fallback_comments(
+        capsys: pytest.CaptureFixture,
+        fake_vcs_client: FakeVCSClient,
+        review_dry_run_comment_gateway: ReviewDryRunCommentGateway,
+):
+    """Dry-run: should preview inline-fallback comments too, matching a real clear."""
+    fake_vcs_client.responses["get_general_comments"] = [
+        ReviewCommentSchema(id="10", body=f"{settings.review.summary_tag} AI summary"),
+        ReviewCommentSchema(id="11", body=f"{settings.review.inline_fallback_tag} AI fallback"),
+        ReviewCommentSchema(id="12", body="a human wrote this"),
+    ]
+
+    await review_dry_run_comment_gateway.clear_summary_comments()
+    output = capsys.readouterr().out
+
+    assert "[dry-run] Would clear 2 AI summary comments" in output
+    assert "[dry-run] Would delete summary comment 10" in output
+    assert "[dry-run] Would delete summary comment 11" in output
+    assert "[dry-run] Would delete summary comment 12" not in output
+
+    assert not any(call[0].startswith("delete_") for call in fake_vcs_client.calls)
+
+
+@pytest.mark.asyncio
 async def test_finalize_does_not_touch_vcs(
         fake_batching_vcs_client: FakeBatchingVCSClient,
         fake_artifacts_service: FakeArtifactsService,

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -40,7 +40,7 @@ ai-review --help
 | `ai-review run-inline-reply`  | Generates **AI replies** to existing inline comment threads.              | `ai-review run-inline-reply`  |
 | `ai-review run-summary-reply` | Generates **AI replies** to existing summary review threads.              | `ai-review run-summary-reply` |
 | `ai-review clear-inline`      | Removes all **AI-generated inline comments** from the review.             | `ai-review clear-inline`      |
-| `ai-review clear-summary`     | Removes all **AI-generated summary comments** from the review.            | `ai-review clear-summary`     |
+| `ai-review clear-summary`     | Removes all **AI summary and inline-fallback comments** from the review.  | `ai-review clear-summary`     |
 | `ai-review show-config`       | Prints the currently resolved configuration (merged from YAML/JSON/ENV).  | `ai-review show-config`       |
 
 ---
@@ -118,7 +118,8 @@ ai-review clear-inline
 
 ### 🧽 Clear Summary Comments
 
-Removes all AI-generated summary comments:
+Removes all AI-generated summary comments,
+including the inline-fallback comments posted when a diff position is rejected:
 
 ```bash
 ai-review clear-summary
@@ -126,10 +127,10 @@ ai-review clear-summary
 
 > ⚠️ **Warning**
 >
-> This command **permanently deletes** all summary review comments created by AI Review.
+> This command **permanently deletes** all summary and inline-fallback comments created by AI Review.
 >
 > - The operation cannot be undone
-> - Only AI Review summary comments are removed
+> - Only AI Review summary and inline-fallback comments are removed
 > - No new comments are created as part of this command
 >
 > Use with caution, especially in shared or long-running pull requests.


### PR DESCRIPTION
## Problem

When an inline comment's diff position is rejected and `review.inline_comment_fallback` is on,
ai-review re-posts it as a general comment tagged `inline_fallback_tag`
(`#ai-review-inline-fallback` by default).

Neither cleanup command is written to remove those comments:
`clear-inline` filters on `inline_tag`, `clear-summary` filters on `summary_tag`.
On providers whose inline listing is strictly inline —
GitHub review comments, Bitbucket, Azure DevOps —
fallback comments therefore accumulate across runs with no cleanup path at all.

They are also the comments most likely to exist in bulk,
since a run that hits one rejected position usually hits several.

## Why this looks like a no-op on GitLab

It is worth being explicit, because on GitLab `clear-inline` *does* already delete these comments —
by accident rather than by design, for two reasons that happen to coincide:

- `#ai-review-inline` is a **substring** of `#ai-review-inline-fallback`,
  and the filters use `tag in comment.body`.
- `GitLabVCSClient.get_inline_comments` maps every note of every discussion with no `position`
  filter, and GitLab's `/discussions` endpoint returns general notes as single-note discussions.

So a fallback comment lands in `get_inline_comments()` and matches the inline tag by prefix.
Neither of those is a property anyone chose,
and the coincidence does not hold for providers with a strict inline listing.
This change makes `clear-summary` cover the case deliberately,
so cleanup completeness stops depending on it.

## Changes

`clear_summary_comments` now selects general comments matching either `summary_tag` or
`inline_fallback_tag`, via a new `get_clearable_summary_comments()` on the gateway.
`ReviewDryRunCommentGateway` overrides `clear_summary_comments` and shares the same method,
so the dry-run preview and a real run report the identical set —
otherwise the preview would under-report what the real command deletes.

`get_summary_comments` is deliberately **unchanged** and stays narrow.
`SummaryReviewRunner.run()` uses it to decide whether a summary already exists;
widening it would let one leftover fallback comment suppress the entire summary review.
That asymmetry is the reason the selection lives in a separate method
rather than in the existing one.

`docs/cli/README.md` is updated, since this changes documented CLI behavior for every provider.

## Testing

760 passing. New coverage:

- `clear-summary` deletes a summary-tagged and a fallback-tagged comment
  while leaving a human comment untouched
- the dry-run gateway previews exactly the same set
- `get_summary_comments` still ignores fallback comments and returns empty,
  which is the condition `SummaryReviewRunner` branches on

## Related observation, no action requested

The substring matching above is a broader behavior, not specific to cleanup:
because `#ai-review-inline` is a prefix of both `#ai-review-inline-fallback` and
`#ai-review-inline-reply` (and `#ai-review-summary` of `#ai-review-summary-reply`),
a single leftover fallback or reply comment makes `InlineReviewRunner.run()` skip the
**whole** inline review on GitLab, since its skip-check is `get_inline_comments()` being
non-empty.

I have not touched that here.
Making tag matching exact would change comment detection for every provider and every tag,
including the skip-checks that decide whether a review runs —
a behavior change existing users would feel, and your call how to land.
Flagging it rather than working around it silently.
