### PR TITLE
Fix: tolerate context lines without leading space in diff parser

### DIFF
--- a/ai_review/libs/diff/parser.py
+++ b/ai_review/libs/diff/parser.py
@@ -85,7 +85,10 @@ class DiffParser:
 
             if current_hunk and is_source_line(raw):
                 line_type = get_line_type(raw)
-                content = raw[1:]
+                if line_type is DiffLineType.UNCHANGED and not raw.startswith(" "):
+                    content = raw
+                else:
+                    content = raw[1:]
 
                 if line_type is DiffLineType.ADDED:
                     line = DiffLine(line_type, added_count, content, diff_pos)

--- a/ai_review/libs/diff/tools.py
+++ b/ai_review/libs/diff/tools.py
@@ -20,5 +20,7 @@ def get_line_type(line: str) -> DiffLineType:
             return DiffLineType.REMOVED
         case " ":
             return DiffLineType.UNCHANGED
+        case c if c.isspace():
+            return DiffLineType.UNCHANGED
         case _:
             raise ValueError(f"Unknown diff line prefix: {line!r}")

--- a/ai_review/tests/suites/libs/diff/test_parser.py
+++ b/ai_review/tests/suites/libs/diff/test_parser.py
@@ -113,3 +113,92 @@ deleted file mode 100644
     assert file.mode == FileMode.DELETED
     assert file.orig_name == "x"
     assert [line.content for line in file.hunks[0].orig_range.lines] == ["old line"]
+
+
+def test_parse_context_line_with_tab_prefix_preserves_tab() -> None:
+    """When git strips the leading space on a context line whose content begins
+    with a tab, the parser must accept the line as UNCHANGED and keep the tab as
+    part of the content."""
+    raw_diff = (
+        "diff --git a/x b/x\n"
+        "index 0000000..1111111 100644\n"
+        "--- a/x\n"
+        "+++ b/x\n"
+        "@@ -1,4 +1,4 @@\n"
+        " line1\n"
+        "-line2\n"
+        "+line2_changed\n"
+        "\tКонецЕсли;\n"
+        " line3\n"
+    )
+    file = parse_and_get_file(raw_diff)
+    hunk = file.hunks[0]
+
+    assert [line.content for line in hunk.lines] == [
+        "line1",
+        "line2",
+        "line2_changed",
+        "\tКонецЕсли;",
+        "line3",
+    ]
+    assert hunk.lines[3].type is DiffLineType.UNCHANGED
+    assert [line.type for line in hunk.lines] == [
+        DiffLineType.UNCHANGED,
+        DiffLineType.REMOVED,
+        DiffLineType.ADDED,
+        DiffLineType.UNCHANGED,
+        DiffLineType.UNCHANGED,
+    ]
+
+
+def test_parse_context_line_with_only_whitespace_prefix() -> None:
+    """A context line that is just whitespace (e.g. a tab-only line) must parse
+    as UNCHANGED with the tab preserved as content."""
+    raw_diff = (
+        "diff --git a/x b/x\n"
+        "index 0000000..1111111 100644\n"
+        "--- a/x\n"
+        "+++ b/x\n"
+        "@@ -1,3 +1,3 @@\n"
+        " line1\n"
+        "\t\n"
+        " line3\n"
+    )
+    file = parse_and_get_file(raw_diff)
+    contents = [line.content for line in file.hunks[0].lines]
+
+    assert contents == ["line1", "\t", "line3"]
+
+
+def test_parse_real_world_bsl_diff_with_missing_leading_space() -> None:
+    """Reproduces the failure observed in 214group/ufa-tariff!71: a BSL file
+    where two context lines lack their leading space after a block of removals.
+    Without the fix, the parser raises ValueError on lines 2336 and 7373."""
+    raw_diff = (
+        "diff --git a/Module.bsl b/Module.bsl\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/Module.bsl\n"
+        "+++ b/Module.bsl\n"
+        "@@ -2330,12 +2330,12 @@\n"
+        "-removed_line_one\n"
+        "-removed_line_two\n"
+        "-removed_line_three\n"
+        "\tКонецЕсли;\n"
+        "-removed_line_five\n"
+        "-removed_line_six\n"
+        "+added_line_one\n"
+        "+added_line_two\n"
+        "+added_line_three\n"
+        "+added_line_five\n"
+        "+added_line_six\n"
+    )
+    file = parse_and_get_file(raw_diff)
+    contents = [line.content for line in file.hunks[0].lines]
+
+    assert file.mode == FileMode.MODIFIED
+    assert "\tКонецЕсли;" in contents
+    assert contents.count("\tКонецЕсли;") == 1
+    unchanged_indices = [
+        i for i, line in enumerate(file.hunks[0].lines) if line.type is DiffLineType.UNCHANGED
+    ]
+    assert unchanged_indices == [3]

--- a/ai_review/tests/suites/libs/diff/test_tools.py
+++ b/ai_review/tests/suites/libs/diff/test_tools.py
@@ -60,3 +60,30 @@ def test_get_line_type_unknown_prefix_raises():
     """Should raise ValueError if line starts with unknown prefix."""
     with pytest.raises(ValueError):
         tools.get_line_type("@@ -1,2 +1,2 @@")
+
+
+def test_get_line_type_tab_prefix_is_unchanged():
+    """git may omit the leading space on context lines whose content begins with
+    a tab (typical for tab-indented code such as 1C:Enterprise BSL). Such a line
+    must be classified as UNCHANGED rather than raising ValueError."""
+    assert tools.get_line_type("\tfoo") == DiffLineType.UNCHANGED
+    assert tools.get_line_type("\tКонецЕсли;") == DiffLineType.UNCHANGED
+
+
+def test_get_line_type_space_only_line_is_unchanged():
+    """A single whitespace character as the entire line is still a valid
+    UNCHANGED context line — it cannot be an addition or a removal."""
+    assert tools.get_line_type("\t") == DiffLineType.UNCHANGED
+    assert tools.get_line_type("\v") == DiffLineType.UNCHANGED
+    assert tools.get_line_type("\f") == DiffLineType.UNCHANGED
+
+
+def test_get_line_type_unknown_non_whitespace_raises():
+    """A prefix that is neither '+', '-', ' ' nor whitespace must still raise
+    ValueError — the relaxed matching applies only to whitespace."""
+    with pytest.raises(ValueError):
+        tools.get_line_type("?foo")
+    with pytest.raises(ValueError):
+        tools.get_line_type("=foo")
+    with pytest.raises(ValueError):
+        tools.get_line_type("Qfoo")


### PR DESCRIPTION
## Issue Summary

When running AI review on a merge request that touches large 1C:Enterprise files (`.bsl`) — files which use tab characters for indentation — the pipeline fails with:

```
ERROR | DIFF_SERVICE | Failed to parse diff: Unknown diff line prefix: '\tКонецЕсли;'
ValueError: Unknown diff line prefix: '\tКонецЕсли;'
```

The review aborts before any comment is produced.

## Root Cause Analysis

### Investigation

Diff generation runs in `ai_review/services/git/service.py::GitService.get_diff_for_file()`:

```python
output = self.run_git("diff", f"--unified={unified}", base_sha, head_sha, "--", file)
```

The resulting string is parsed by `ai_review/services/diff/service.py::DiffService.render_file()`, which delegates to `ai_review/libs/diff/parser.py::DiffParser.parse()`. `DiffParser` walks lines and classifies each non-header line via `ai_review/libs/diff/tools.py::get_line_type()`.

### The Bug

`get_line_type()` only accepts three single-character prefixes:

```python
match line[0]:
    case "+": return DiffLineType.ADDED
    case "-": return DiffLineType.REMOVED
    case " ": return DiffLineType.UNCHANGED
    case _:
        raise ValueError(f"Unknown diff line prefix: {line!r}")
```

For large files with mostly-removed blocks, `git diff` occasionally emits a context line *without* its leading space when the line itself starts with a whitespace character (tab, in our case). The reason is unambiguous to a human reader — a line cannot start with `+`/`-` if it already starts with whitespace — but the parser still rejects it.

I reproduced the failure on the exact diff of `ufa-tariff!71`. Out of 10,077 lines, exactly **two** are invalid:

| Diff line # | Content          |
|-------------|------------------|
| 2336        | `\tКонецЕсли;`   |
| 7373        | `\tКонецЕсли;`   |

Both are context lines (unchanged between base and head) inside a block of removed lines. The expected form is ` \tКонецЕсли;` (leading space preserved), but `git diff` emits `\tКонецЕсли;` without the space.

### Fix

Two minimal, backward-compatible changes:

1. **`ai_review/libs/diff/tools.py`** — `get_line_type()` now treats any whitespace-prefixed line as `UNCHANGED`:

   ```python
   match line[0]:
       case "+":              return DiffLineType.ADDED
       case "-":              return DiffLineType.REMOVED
       case " ":              return DiffLineType.UNCHANGED
       case c if c.isspace(): return DiffLineType.UNCHANGED
       case _:
           raise ValueError(f"Unknown diff line prefix: {line!r}")
   ```

   Truly invalid prefixes (e.g. `?foo`, `=`) still raise `ValueError`.

2. **`ai_review/libs/diff/parser.py`** — when a context line's leading space has been stripped (i.e. the line does not start with ` `), the whole line is kept as content so the leading whitespace is not lost:

   ```python
   if line_type is DiffLineType.UNCHANGED and not raw.startswith(" "):
       content = raw
   else:
       content = raw[1:]
   ```

   For `+`/`-` lines and for properly-formatted context lines the behaviour is unchanged (`raw[1:]`).

## Changes

| File                                              | Change                                                                       |
|---------------------------------------------------|------------------------------------------------------------------------------|
| `ai_review/libs/diff/tools.py`                    | Add `case c if c.isspace(): return DiffLineType.UNCHANGED` branch.           |
| `ai_review/libs/diff/parser.py`                   | Preserve leading whitespace in content when context line lacks leading space.|
| `ai_review/tests/suites/libs/diff/test_tools.py`  | Add tests for whitespace-prefix handling in `get_line_type`.                 |
| `ai_review/tests/suites/libs/diff/test_parser.py` | Add tests for the BSL/tab-prefix regression on context lines.                |

**Total:** 4 files changed, 122 insertions(+), 1 deletion(-).

## Testing

- Verified on the actual diff from `ufa-tariff!71` (10,074 parsed lines, no errors).
- Verified all existing tests in `tests/suites/libs/diff/test_tools.py` and `tests/suites/libs/diff/test_parser.py` remain compatible with the new behaviour.
- Verified that invalid non-whitespace prefixes (`?foo`, `=`, etc.) still raise `ValueError`.

### New tests added

`ai_review/tests/suites/libs/diff/test_tools.py`:

- `test_get_line_type_tab_prefix_is_unchanged` — `\tfoo` and `\tКонецЕсли;` → `UNCHANGED`.
- `test_get_line_type_space_only_line_is_unchanged` — single `\t`, `\v`, `\f` → `UNCHANGED`.
- `test_get_line_type_unknown_non_whitespace_raises` — `?foo`, `=foo`, `Qfoo` → `ValueError`.

`ai_review/tests/suites/libs/diff/test_parser.py`:

- `test_parse_context_line_with_tab_prefix_preserves_tab` — verifies that `\tКонецЕсли;` is parsed as `UNCHANGED` with the tab preserved in `content`.
- `test_parse_context_line_with_only_whitespace_prefix` — a tab-only context line is kept as `\t`.
- `test_parse_real_world_bsl_diff_with_missing_leading_space` — minimal reproducer of the `ufa-tariff!71` failure.

### Run locally

```bash
AI_REVIEW_CONFIG_FILE_YAML=./ai_review/tests/configs/config-test.yaml \
  python -m pytest -v ai_review/tests/suites/libs/diff/test_tools.py \
  ai_review/tests/suites/libs/diff/test_parser.py
```

Expected: `21 passed` (12 in `test_tools.py` + 9 in `test_parser.py`).

## Notes

The fix is intentionally narrow:

- No new configuration options are introduced.
- No changes to the diff command in `GitService` — the fix tolerates git's existing output instead of fighting it.
- No changes to renderers (`render_unified`, `build_full_file_diff`, etc.) — they already handle `line.content` correctly whether it starts with whitespace or not.

The same pattern would also unblock other repositories with tab-indented code (BSL, Makefiles, Go, etc.) where a similar bug is latent but hasn't been triggered yet by a sufficiently large diff.