### PR TITLE
fix(gitlab): send a complete diff position so inline comments on unchanged lines are not rejected

### DIFF
--- a/ai_review/libs/diff/models.py
+++ b/ai_review/libs/diff/models.py
@@ -1,5 +1,14 @@
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import Literal
+
+Side = Literal["new", "old"]
+"""Which file of the change a line number belongs to.
+
+A bare line number cannot say: a removed line is numbered in the old file and an
+added line in the new one, so the same number can address two different lines of
+the same diff. A caller that knows the side says so and skips the guess.
+"""
 
 
 class FileMode(Enum):
@@ -108,20 +117,39 @@ class DiffFile:
 
         return positions
 
-    def find_line_position(self, line: int) -> DiffLinePosition | None:
+    def find_line_position(self, line: int, side: Side | None = None) -> DiffLinePosition | None:
         """
-        Resolve a bare line number to the diff line it addresses.
+        Resolve a line number to the diff line it addresses.
 
-        The number is read as a new-file line first, which covers added and
-        unchanged lines and matches how the diff is rendered for the model. Only
-        if no new-file line matches is it read as the old-file line of a removed
-        line, which is the one case that has no new-file number at all.
+        `side` names the file the number was read from, and is authoritative when
+        given. `"old"` matches the old file, so a removed line is found by its own
+        number even when that number is also a new-file line elsewhere in the
+        diff; `"new"` matches the new file and never falls back, so a number
+        declared as new-file is not silently reinterpreted.
+
+        Without a side the number is a bare one — all that
+        `create_inline_comment(file, line, message)` carries — and the reading is
+        a guess: new-file first, which covers added and unchanged lines and
+        matches how the diff is rendered for the model, then the old-file line of
+        a removed line, the one case that has no new-file number at all. Where
+        both readings are possible the new side wins, which can mis-anchor a
+        comment about a deleted line; passing `side` is how a caller avoids that.
         """
         positions = self.line_positions()
+
+        if side == "old":
+            for position in positions:
+                if position.old_line == line:
+                    return position
+
+            return None
 
         for position in positions:
             if position.new_line == line:
                 return position
+
+        if side == "new":
+            return None
 
         for position in positions:
             if position.type is DiffLineType.REMOVED and position.old_line == line:

--- a/ai_review/libs/diff/models.py
+++ b/ai_review/libs/diff/models.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import List
 
 
 class FileMode(Enum):
@@ -41,7 +40,7 @@ class DiffLinePosition:
 class DiffRange:
     start: int
     length: int
-    lines: List[DiffLine]
+    lines: list[DiffLine]
 
 
 @dataclass
@@ -49,7 +48,7 @@ class DiffHunk:
     header: str
     orig_range: DiffRange
     new_range: DiffRange
-    lines: List[DiffLine]
+    lines: list[DiffLine]
 
 
 @dataclass
@@ -58,7 +57,7 @@ class DiffFile:
     mode: FileMode
     orig_name: str
     new_name: str
-    hunks: List[DiffHunk]
+    hunks: list[DiffHunk]
 
     def added_new_lines(self) -> list[DiffLine]:
         return [
@@ -133,7 +132,7 @@ class DiffFile:
 
 @dataclass
 class Diff:
-    files: List[DiffFile]
+    files: list[DiffFile]
     raw: str
 
     def summary(self) -> str:

--- a/ai_review/libs/diff/models.py
+++ b/ai_review/libs/diff/models.py
@@ -24,6 +24,20 @@ class DiffLine:
 
 
 @dataclass
+class DiffLinePosition:
+    """
+    A diff line addressed on both sides of the change.
+
+    An added line exists only in the new file, a removed line only in the old
+    one, and an unchanged line in both. VCS providers that validate a diff
+    position need the pair, not just one side.
+    """
+    type: DiffLineType
+    old_line: int | None
+    new_line: int | None
+
+
+@dataclass
 class DiffRange:
     start: int
     length: int
@@ -67,6 +81,54 @@ class DiffFile:
 
     def removed_line_numbers(self) -> set[int]:
         return {line.number for line in self.removed_old_lines() if line.number is not None}
+
+    def line_positions(self) -> list[DiffLinePosition]:
+        """
+        Pair old and new line numbers for every line of every hunk.
+
+        Each hunk is numbered from its own `@@ -a,b +c,d @@` header, so an
+        earlier hunk that inserts or deletes lines cannot shift a later one.
+        """
+        positions: list[DiffLinePosition] = []
+
+        for hunk in self.hunks:
+            old_line = hunk.orig_range.start
+            new_line = hunk.new_range.start
+
+            for line in hunk.lines:
+                if line.type is DiffLineType.ADDED:
+                    positions.append(DiffLinePosition(line.type, None, new_line))
+                    new_line += 1
+                elif line.type is DiffLineType.REMOVED:
+                    positions.append(DiffLinePosition(line.type, old_line, None))
+                    old_line += 1
+                else:
+                    positions.append(DiffLinePosition(line.type, old_line, new_line))
+                    old_line += 1
+                    new_line += 1
+
+        return positions
+
+    def find_line_position(self, line: int) -> DiffLinePosition | None:
+        """
+        Resolve a bare line number to the diff line it addresses.
+
+        The number is read as a new-file line first, which covers added and
+        unchanged lines and matches how the diff is rendered for the model. Only
+        if no new-file line matches is it read as the old-file line of a removed
+        line, which is the one case that has no new-file number at all.
+        """
+        positions = self.line_positions()
+
+        for position in positions:
+            if position.new_line == line:
+                return position
+
+        for position in positions:
+            if position.type is DiffLineType.REMOVED and position.old_line == line:
+                return position
+
+        return None
 
 
 @dataclass

--- a/ai_review/libs/diff/parser.py
+++ b/ai_review/libs/diff/parser.py
@@ -43,7 +43,7 @@ class DiffParser:
                 continue
 
             # Дополняем header файла
-            if raw.startswith("index ") or raw.startswith("--- ") or raw.startswith("+++ "):
+            if raw.startswith(("index ", "--- ", "+++ ")):
                 # Diff bodies without a `diff ` line, e.g. the GitLab changes API payload
                 if current_file is None:
                     current_file = cls.start_file(files)

--- a/ai_review/libs/diff/parser.py
+++ b/ai_review/libs/diff/parser.py
@@ -17,6 +17,12 @@ NEW_FILE_PREFIX = "+++ b/"
 
 
 class DiffParser:
+    @staticmethod
+    def start_file(files: list[DiffFile], header: str = "") -> DiffFile:
+        file = DiffFile(header=header, mode=FileMode.MODIFIED, orig_name="", new_name="", hunks=[])
+        files.append(file)
+        return file
+
     @classmethod
     def parse(cls, diff_string: str) -> Diff:
         lines = diff_string.split("\n")
@@ -33,19 +39,16 @@ class DiffParser:
 
             # Начало нового файла
             if raw.startswith("diff "):
-                current_file = DiffFile(
-                    header=raw,
-                    mode=FileMode.MODIFIED,
-                    orig_name="",
-                    new_name="",
-                    hunks=[],
-                )
-                files.append(current_file)
+                current_file = cls.start_file(files, header=raw)
                 continue
 
             # Дополняем header файла
             if raw.startswith("index ") or raw.startswith("--- ") or raw.startswith("+++ "):
-                current_file.header += "\n" + raw
+                # Diff bodies without a `diff ` line, e.g. the GitLab changes API payload
+                if current_file is None:
+                    current_file = cls.start_file(files)
+
+                current_file.header = f"{current_file.header}\n{raw}" if current_file.header else raw
 
             if raw.startswith(OLD_FILE_PREFIX):
                 current_file.orig_name = raw[len(OLD_FILE_PREFIX):]
@@ -67,6 +70,10 @@ class DiffParser:
                 match = HUNK_RE.match(raw)
                 if not match:
                     raise ValueError(f"Invalid hunk header: {raw}")
+
+                # Diff bodies without a `diff ` line, e.g. the GitLab changes API payload
+                if current_file is None:
+                    current_file = cls.start_file(files)
 
                 a, b, c, d, header = match.groups()
                 orig_start, orig_len = int(a), int(b or 0)

--- a/ai_review/services/review/gateway/review_comment_gateway.py
+++ b/ai_review/services/review/gateway/review_comment_gateway.py
@@ -106,6 +106,7 @@ class ReviewCommentGateway(ReviewCommentGatewayProtocol):
                 file=comment.file,
                 line=comment.line,
                 message=comment.body_with_tag,
+                side=comment.side,
             )
             await hook.emit_inline_comment_complete(comment)
 

--- a/ai_review/services/review/internal/inline/schema.py
+++ b/ai_review/services/review/internal/inline/schema.py
@@ -3,8 +3,9 @@ from typing import Self
 from pydantic import BaseModel, Field, RootModel, field_validator
 
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 
-DedupKey = tuple[str, int, str]
+DedupKey = tuple[str, int, Side | None, str]
 
 
 class InlineCommentSchema(BaseModel):
@@ -12,6 +13,14 @@ class InlineCommentSchema(BaseModel):
     line: int = Field(ge=1)
     message: str = Field(min_length=1)
     suggestion: str | None = None
+    side: Side | None = None
+    """Which file of the diff `line` is numbered in, when the caller knows.
+
+    A removed line is numbered in the old file, so its number can collide with
+    an unrelated new-file line and a provider that has to guess anchors the
+    comment to the wrong code. `None` means no claim is made, which is all the
+    LLM review path can say: it reads a rendered diff and reports a bare number.
+    """
 
     @field_validator("file")
     def normalize_file(cls, value: str) -> str:
@@ -24,7 +33,13 @@ class InlineCommentSchema(BaseModel):
 
     @property
     def dedup_key(self) -> DedupKey:
-        return self.file, self.line, (self.suggestion or self.message).strip().lower()
+        """Identify the comment by where it points and what it says.
+
+        `side` belongs to the location: the same number on the two sides of a
+        change addresses two different lines, so collapsing them would drop a
+        finding rather than a duplicate.
+        """
+        return self.file, self.line, self.side, (self.suggestion or self.message).strip().lower()
 
     @property
     def body(self) -> str:
@@ -39,6 +54,15 @@ class InlineCommentSchema(BaseModel):
 
     @property
     def fallback_body(self) -> str:
+        """Render the comment as a general comment, naming the line in the text.
+
+        A number on the old side would send the reader to whatever now occupies
+        that line in the new file, so it is marked. The new side is the reading
+        everyone assumes and is left alone.
+        """
+        if self.side == "old":
+            return f"**{self.file}:{self.line} (old side)** — {self.message}"
+
         return f"**{self.file}:{self.line}** — {self.message}"
 
 

--- a/ai_review/services/vcs/azure_devops/client.py
+++ b/ai_review/services/vcs/azure_devops/client.py
@@ -8,6 +8,7 @@ from ai_review.clients.azure_devops.pr.schema.threads import (
     AzureDevOpsPullRequestThreadContextSchema,
 )
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.azure_devops.adapter import get_review_comment_from_azure_devops_comment
 from ai_review.services.vcs.types import (
@@ -169,7 +170,8 @@ class AzureDevOpsVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in {self.pull_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        # Azure DevOps anchors on the right-hand file only; `side` is accepted for the protocol and ignored.
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
 

--- a/ai_review/services/vcs/bitbucket_cloud/client.py
+++ b/ai_review/services/vcs/bitbucket_cloud/client.py
@@ -8,6 +8,7 @@ from ai_review.clients.bitbucket_cloud.pr.schema.comments import (
     BitbucketCloudCreatePRCommentRequestSchema,
 )
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.bitbucket_cloud.adapter import get_review_comment_from_bitbucket_pr_comment
 from ai_review.services.vcs.types import (
@@ -146,7 +147,8 @@ class BitbucketCloudVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in PR {self.pull_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        # Bitbucket Cloud anchors on the destination file only; `side` is accepted for the protocol and ignored.
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
             request = BitbucketCloudCreatePRCommentRequestSchema(

--- a/ai_review/services/vcs/bitbucket_server/client.py
+++ b/ai_review/services/vcs/bitbucket_server/client.py
@@ -7,6 +7,7 @@ from ai_review.clients.bitbucket_server.pr.schema.comments import (
     BitbucketServerCreatePRCommentRequestSchema,
 )
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.bitbucket_server.adapter import get_review_comment_from_bitbucket_server_comment
 from ai_review.services.vcs.bitbucket_server.tools import get_comments_from_activities
@@ -144,7 +145,8 @@ class BitbucketServerVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in PR {self.pull_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        # Bitbucket Server anchors an ADDED line only; `side` is accepted for the protocol and ignored.
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
 

--- a/ai_review/services/vcs/gitea/client.py
+++ b/ai_review/services/vcs/gitea/client.py
@@ -5,6 +5,7 @@ from ai_review.clients.gitea.pr.schema.reviews import (
     GiteaCreateReviewRequestSchema,
 )
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.gitea.adapter import (
     get_user_from_gitea_user,
@@ -121,7 +122,8 @@ class GiteaVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in PR {self.pull_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        # Gitea anchors on the new file only; `side` is accepted for the protocol and ignored.
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
 

--- a/ai_review/services/vcs/github/client.py
+++ b/ai_review/services/vcs/github/client.py
@@ -6,6 +6,7 @@ from ai_review.clients.github.pr.schema.comments import (
     GitHubCreateReviewCommentRequestSchema
 )
 from ai_review.config import settings
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.github.adapter import (
     get_review_comment_from_github_pr_comment,
@@ -125,7 +126,8 @@ class GitHubVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create general comment in PR {self.pull_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        # GitHub anchors on the new file only; `side` is accepted for the protocol and ignored.
         try:
             logger.info(f"Posting inline comment in {self.pull_request_ref} at {file}:{line}: {message}")
 

--- a/ai_review/services/vcs/gitlab/client.py
+++ b/ai_review/services/vcs/gitlab/client.py
@@ -5,6 +5,7 @@ from ai_review.clients.gitlab.mr.schema.discussions import GitLabCreateMRDiscuss
 from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabCreateMRDraftNoteRequestSchema
 from ai_review.config import settings
 from ai_review.libs.asynchronous.gather import bounded_gather
+from ai_review.libs.diff.models import Side
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.gitlab.adapter import get_user_from_gitlab_user, get_review_comment_from_gitlab_note
 from ai_review.services.vcs.gitlab.position import build_inline_position
@@ -215,9 +216,9 @@ class GitLabVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create draft general comment in {self.merge_request_ref}: {error}")
             raise
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
         if settings.vcs.batch_comments:
-            await self.create_draft_inline_comment(file=file, line=line, message=message)
+            await self.create_draft_inline_comment(file=file, line=line, message=message, side=side)
             return
 
         try:
@@ -233,6 +234,7 @@ class GitLabVCSClient(VCSClientProtocol):
                 position=build_inline_position(
                     file=file,
                     line=line,
+                    side=side,
                     diff_refs=response.diff_refs,
                     changes=response.changes,
                 ),
@@ -247,7 +249,13 @@ class GitLabVCSClient(VCSClientProtocol):
             logger.exception(f"Failed to create inline comment in {self.merge_request_ref} at {file}:{line}: {error}")
             raise
 
-    async def create_draft_inline_comment(self, file: str, line: int, message: str) -> None:
+    async def create_draft_inline_comment(
+            self,
+            file: str,
+            line: int,
+            message: str,
+            side: Side | None = None,
+    ) -> None:
         await self.discard_stale_draft_comments()
 
         try:
@@ -263,6 +271,7 @@ class GitLabVCSClient(VCSClientProtocol):
                 position=build_inline_position(
                     file=file,
                     line=line,
+                    side=side,
                     diff_refs=response.diff_refs,
                     changes=response.changes,
                 ),

--- a/ai_review/services/vcs/gitlab/client.py
+++ b/ai_review/services/vcs/gitlab/client.py
@@ -3,11 +3,11 @@ import asyncio
 from ai_review.clients.gitlab.client import get_gitlab_http_client
 from ai_review.clients.gitlab.mr.schema.discussions import GitLabCreateMRDiscussionRequestSchema
 from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabCreateMRDraftNoteRequestSchema
-from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
 from ai_review.config import settings
 from ai_review.libs.asynchronous.gather import bounded_gather
 from ai_review.libs.logger import get_logger
 from ai_review.services.vcs.gitlab.adapter import get_user_from_gitlab_user, get_review_comment_from_gitlab_note
+from ai_review.services.vcs.gitlab.position import build_inline_position
 from ai_review.services.vcs.gitlab.tools import filter_ai_review_drafts
 from ai_review.services.vcs.types import (
     VCSClientProtocol,
@@ -230,13 +230,11 @@ class GitLabVCSClient(VCSClientProtocol):
 
             request = GitLabCreateMRDiscussionRequestSchema(
                 body=message,
-                position=GitLabPositionSchema(
-                    position_type="text",
-                    base_sha=response.diff_refs.base_sha,
-                    head_sha=response.diff_refs.head_sha,
-                    start_sha=response.diff_refs.start_sha,
-                    new_path=file,
-                    new_line=line,
+                position=build_inline_position(
+                    file=file,
+                    line=line,
+                    diff_refs=response.diff_refs,
+                    changes=response.changes,
                 ),
             )
             await self.http_client.mr.create_discussion(
@@ -262,13 +260,11 @@ class GitLabVCSClient(VCSClientProtocol):
 
             request = GitLabCreateMRDraftNoteRequestSchema(
                 note=message,
-                position=GitLabPositionSchema(
-                    position_type="text",
-                    base_sha=response.diff_refs.base_sha,
-                    head_sha=response.diff_refs.head_sha,
-                    start_sha=response.diff_refs.start_sha,
-                    new_path=file,
-                    new_line=line,
+                position=build_inline_position(
+                    file=file,
+                    line=line,
+                    diff_refs=response.diff_refs,
+                    changes=response.changes,
                 ),
             )
             await self.http_client.mr.create_draft_note(

--- a/ai_review/services/vcs/gitlab/position.py
+++ b/ai_review/services/vcs/gitlab/position.py
@@ -1,5 +1,6 @@
 from ai_review.clients.gitlab.mr.schema.changes import GitLabDiffRefsSchema, GitLabMRChangeSchema
 from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
+from ai_review.libs.diff.models import Side
 from ai_review.libs.diff.parser import DiffParser
 from ai_review.libs.logger import get_logger
 from ai_review.services.diff.tools import normalize_file_path
@@ -26,6 +27,7 @@ def build_inline_position(
         line: int,
         diff_refs: GitLabDiffRefsSchema,
         changes: list[GitLabMRChangeSchema],
+        side: Side | None = None,
 ) -> GitLabPositionSchema:
     """
     Build the diff position of an inline comment.
@@ -38,11 +40,18 @@ def build_inline_position(
     Resolving the line against the diff GitLab itself reported lets us send both
     numbers, and lets us address a removed line by its old number.
 
+    `side` says which file `line` is numbered in. Without it the number is read
+    as a new-file line first, which is the only thing a bare number supports but
+    is still a guess: a removed line's old number is frequently also a new-file
+    number in the same diff, and then the comment lands on unrelated code with no
+    error to show for it. A caller that resolved the line itself passes the side
+    and the guess is skipped.
+
     When the line cannot be resolved — the file is absent from the changes
-    payload, GitLab omitted the diff body, or the body does not parse — the
-    position keeps `new_path` and `new_line` only. That is what the caller sent
-    before, so such comments keep taking the same path through the inline
-    fallback as they do today.
+    payload, GitLab omitted the diff body, the body does not parse, or the number
+    is not a line of the declared side — the position keeps `new_path` and
+    `new_line` only. That is what the caller sent before, so such comments keep
+    taking the same path through the inline fallback as they do today.
     """
     position = GitLabPositionSchema(
         position_type="text",
@@ -70,9 +79,9 @@ def build_inline_position(
         logger.warning(f"MR diff of {file} contains no hunks, cannot resolve the old line of {file}:{line}")
         return position
 
-    line_position = diff.files[0].find_line_position(line)
+    line_position = diff.files[0].find_line_position(line, side=side)
     if line_position is None:
-        logger.warning(f"Line {line} is not part of the MR diff of {file}")
+        logger.warning(f"Line {line} is not part of the MR diff of {file} on side {side or 'new/old'}")
         return position
 
     return position.model_copy(

--- a/ai_review/services/vcs/gitlab/position.py
+++ b/ai_review/services/vcs/gitlab/position.py
@@ -1,0 +1,85 @@
+from ai_review.clients.gitlab.mr.schema.changes import GitLabDiffRefsSchema, GitLabMRChangeSchema
+from ai_review.clients.gitlab.mr.schema.position import GitLabPositionSchema
+from ai_review.libs.diff.parser import DiffParser
+from ai_review.libs.logger import get_logger
+from ai_review.services.diff.tools import normalize_file_path
+
+logger = get_logger("GITLAB_POSITION")
+
+
+def find_change(changes: list[GitLabMRChangeSchema], file: str) -> GitLabMRChangeSchema | None:
+    """Find the MR change entry describing a file, matching either side of a rename."""
+    target = normalize_file_path(file)
+
+    for change in changes:
+        if normalize_file_path(change.new_path or "") == target:
+            return change
+        if normalize_file_path(change.old_path or "") == target:
+            return change
+
+    return None
+
+
+def build_inline_position(
+        *,
+        file: str,
+        line: int,
+        diff_refs: GitLabDiffRefsSchema,
+        changes: list[GitLabMRChangeSchema],
+) -> GitLabPositionSchema:
+    """
+    Build the diff position of an inline comment.
+
+    GitLab turns a text position into a line code by looking for the diff line
+    carrying exactly the given `old_line` and `new_line`. An added line has no
+    counterpart in the old file, so `new_line` alone identifies it. An unchanged
+    line carries both numbers, so `new_line` alone matches nothing and the note
+    is rejected with `line_code can't be blank, must be a valid line code`.
+    Resolving the line against the diff GitLab itself reported lets us send both
+    numbers, and lets us address a removed line by its old number.
+
+    When the line cannot be resolved — the file is absent from the changes
+    payload, GitLab omitted the diff body, or the body does not parse — the
+    position keeps `new_path` and `new_line` only. That is what the caller sent
+    before, so such comments keep taking the same path through the inline
+    fallback as they do today.
+    """
+    position = GitLabPositionSchema(
+        position_type="text",
+        base_sha=diff_refs.base_sha,
+        head_sha=diff_refs.head_sha,
+        start_sha=diff_refs.start_sha,
+        new_path=file,
+        new_line=line,
+    )
+
+    change = find_change(changes, file)
+    if change is None or not change.diff:
+        logger.warning(f"No MR diff available for {file}, cannot resolve the old line of {file}:{line}")
+        return position
+
+    try:
+        # Resolution is best effort: a diff we cannot parse must never keep a
+        # comment from being created.
+        diff = DiffParser.parse(change.diff)
+    except Exception as error:
+        logger.warning(f"Failed to parse the MR diff of {file}: {error}")
+        return position
+
+    if not diff.files:
+        logger.warning(f"MR diff of {file} contains no hunks, cannot resolve the old line of {file}:{line}")
+        return position
+
+    line_position = diff.files[0].find_line_position(line)
+    if line_position is None:
+        logger.warning(f"Line {line} is not part of the MR diff of {file}")
+        return position
+
+    return position.model_copy(
+        update={
+            "old_path": change.old_path or file,
+            "new_path": change.new_path or file,
+            "old_line": line_position.old_line,
+            "new_line": line_position.new_line,
+        }
+    )

--- a/ai_review/services/vcs/types.py
+++ b/ai_review/services/vcs/types.py
@@ -3,6 +3,8 @@ from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
+from ai_review.libs.diff.models import Side
+
 
 class ThreadKind(StrEnum):
     INLINE = "INLINE"
@@ -74,8 +76,16 @@ class VCSClientProtocol(Protocol):
     async def create_general_comment(self, message: str) -> None:
         """Post a top-level comment."""
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
-        """Post a comment attached to a specific line in file."""
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        """Post a comment attached to a specific line in file.
+
+        `side` says which file of the change `line` is numbered in, for the
+        callers that know: a removed line is numbered in the old file, so its
+        number can also be an unrelated new-file line. `None` claims nothing and
+        leaves the provider to resolve the number as it always has. A provider
+        that cannot address the old side ignores `side` and anchors on the new
+        one, exactly as before.
+        """
 
     async def delete_general_comment(self, comment_id: int | str) -> None:
         """Delete a top-level (general / summary) review comment by its identifier."""

--- a/ai_review/tests/fixtures/clients/gitlab.py
+++ b/ai_review/tests/fixtures/clients/gitlab.py
@@ -38,6 +38,13 @@ class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
         self.calls: list[tuple[str, dict]] = []
         self.draft_notes: list[GitLabDraftNoteSchema] = []
         self.get_draft_notes_error: Exception | None = None
+        self.changes: list[GitLabMRChangeSchema] = [
+            GitLabMRChangeSchema(
+                diff="@@ -1,2 +1,2 @@\n- old\n+ new",
+                old_path="main.py",
+                new_path="main.py",
+            )
+        ]
 
     async def get_changes(self, project_id: str, merge_request_id: str) -> GitLabGetMRChangesResponseSchema:
         self.calls.append(("get_changes", {"project_id": project_id, "merge_request_id": merge_request_id}))
@@ -56,13 +63,7 @@ class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
             ),
             source_branch="feature/test",
             target_branch="main",
-            changes=[
-                GitLabMRChangeSchema(
-                    diff="@@ -1,2 +1,2 @@\n- old\n+ new",
-                    old_path="main.py",
-                    new_path="main.py",
-                )
-            ],
+            changes=self.changes,
         )
 
     async def get_notes(self, project_id: str, merge_request_id: str) -> GitLabGetMRNotesResponseSchema:
@@ -146,7 +147,12 @@ class FakeGitLabMergeRequestsHTTPClient(GitLabMergeRequestsHTTPClientProtocol):
         self.calls.append(
             (
                 "create_discussion",
-                {"project_id": project_id, "merge_request_id": merge_request_id, "body": request.body}
+                {
+                    "project_id": project_id,
+                    "merge_request_id": merge_request_id,
+                    "body": request.body,
+                    "position": request.position,
+                }
             )
         )
         return GitLabCreateMRDiscussionResponseSchema(

--- a/ai_review/tests/fixtures/services/vcs.py
+++ b/ai_review/tests/fixtures/services/vcs.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from ai_review.libs.diff.models import Side
 from ai_review.services.vcs.types import (
     VCSClientProtocol,
     ReviewInfoSchema,
@@ -37,8 +38,8 @@ class FakeVCSClient(VCSClientProtocol):
 
         return self.responses.get("create_general_comment_result", None)
 
-    async def create_inline_comment(self, file: str, line: int, message: str) -> None:
-        self.calls.append(("create_inline_comment", (file, line, message), {}))
+    async def create_inline_comment(self, file: str, line: int, message: str, side: Side | None = None) -> None:
+        self.calls.append(("create_inline_comment", (file, line, message), {"side": side}))
         if error := self.responses.get("create_inline_comment_error"):
             raise error
 

--- a/ai_review/tests/suites/libs/diff/test_models.py
+++ b/ai_review/tests/suites/libs/diff/test_models.py
@@ -9,6 +9,30 @@ from ai_review.libs.diff.models import (
     Diff,
     FileMode,
 )
+from ai_review.libs.diff.parser import DiffParser
+
+TWO_HUNK_DIFF = """@@ -80,4 +80,5 @@
+ class Store:
+     def __init__(self, session):
++        self.cache = {}
+     def get(self, key):
+         return self.session.get(key)
+@@ -126,4 +127,5 @@
+ def remove(session, key):
+     entry = session.get(key)
+-    session.delete(entry)
++    session.mark_deleted(entry)
++    session.flush()
+     session.commit()
+"""
+
+DELETION_DIFF = """@@ -1,5 +1,2 @@
+ alpha
+-beta
+-gamma
+-delta
+ epsilon
+"""
 
 
 # ---------- fixtures ----------
@@ -55,6 +79,18 @@ def diff_with_modified_file(diff_file_modified: DiffFile) -> Diff:
     return Diff(files=[diff_file_modified], raw="raw-diff-here")
 
 
+@pytest.fixture
+def two_hunk_file() -> DiffFile:
+    """Two hunks where the first inserts a line, so the second is shifted by one."""
+    return DiffParser.parse(TWO_HUNK_DIFF).files[0]
+
+
+@pytest.fixture
+def deletion_file() -> DiffFile:
+    """A hunk that only deletes, so old line numbers run ahead of new ones."""
+    return DiffParser.parse(DELETION_DIFF).files[0]
+
+
 # ---------- tests ----------
 
 def test_added_and_removed_lines(diff_file_modified: DiffFile) -> None:
@@ -88,6 +124,83 @@ def test_changed_lines_and_files(diff_with_modified_file: Diff) -> None:
 
     assert changed == {"b/file": [3]}
     assert files == ["b/file"]
+
+
+def test_line_positions_pairs_every_line_of_every_hunk(two_hunk_file: DiffFile) -> None:
+    """line_positions should pair old and new numbers for each line, hunk by hunk."""
+    positions = two_hunk_file.line_positions()
+
+    assert [(position.old_line, position.new_line) for position in positions] == [
+        (80, 80),  # class Store:
+        (81, 81),  # def __init__(self, session):
+        (None, 82),  # + self.cache = {}
+        (82, 83),  # def get(self, key):
+        (83, 84),  # return self.session.get(key)
+        (126, 127),  # def remove(session, key):
+        (127, 128),  # entry = session.get(key)
+        (128, None),  # - session.delete(entry)
+        (None, 129),  # + session.mark_deleted(entry)
+        (None, 130),  # + session.flush()
+        (129, 131),  # session.commit()
+    ]
+
+
+def test_find_line_position_for_added_line(two_hunk_file: DiffFile) -> None:
+    """An added line has a new number and no old number."""
+    position = two_hunk_file.find_line_position(82)
+
+    assert position is not None
+    assert position.type is DiffLineType.ADDED
+    assert (position.old_line, position.new_line) == (None, 82)
+
+
+def test_find_line_position_for_context_line(two_hunk_file: DiffFile) -> None:
+    """A context line carries both numbers, which is what GitLab needs to resolve it."""
+    position = two_hunk_file.find_line_position(84)
+
+    assert position is not None
+    assert position.type is DiffLineType.UNCHANGED
+    assert (position.old_line, position.new_line) == (83, 84)
+
+
+def test_find_line_position_across_hunks_accounts_for_shift(two_hunk_file: DiffFile) -> None:
+    """A context line in a later hunk keeps the offset introduced by an earlier one."""
+    position = two_hunk_file.find_line_position(131)
+
+    assert position is not None
+    assert position.type is DiffLineType.UNCHANGED
+    assert (position.old_line, position.new_line) == (129, 131)
+
+
+def test_find_line_position_for_removed_line(deletion_file: DiffFile) -> None:
+    """A number that matches no new line is resolved against removed old lines."""
+    position = deletion_file.find_line_position(3)
+
+    assert position is not None
+    assert position.type is DiffLineType.REMOVED
+    assert (position.old_line, position.new_line) == (3, None)
+
+
+def test_find_line_position_prefers_the_new_side(deletion_file: DiffFile) -> None:
+    """When a number is valid on both sides, the new side wins."""
+    position = deletion_file.find_line_position(2)
+
+    assert position is not None
+    assert position.type is DiffLineType.UNCHANGED
+    assert (position.old_line, position.new_line) == (5, 2)
+
+
+def test_find_line_position_returns_none_for_unknown_line(two_hunk_file: DiffFile) -> None:
+    """A line outside every hunk cannot be resolved."""
+    assert two_hunk_file.find_line_position(500) is None
+
+
+def test_find_line_position_returns_none_without_hunks() -> None:
+    """A file with no hunks resolves nothing."""
+    file = DiffFile(header="", mode=FileMode.MODIFIED, orig_name="x", new_name="x", hunks=[])
+
+    assert file.line_positions() == []
+    assert file.find_line_position(1) is None
 
 
 def test_changed_files_skips_deleted(diff_file_modified: DiffFile) -> None:

--- a/ai_review/tests/suites/libs/diff/test_models.py
+++ b/ai_review/tests/suites/libs/diff/test_models.py
@@ -8,6 +8,7 @@ from ai_review.libs.diff.models import (
     DiffFile,
     Diff,
     FileMode,
+    DiffLinePosition,
 )
 from ai_review.libs.diff.parser import DiffParser
 
@@ -188,6 +189,58 @@ def test_find_line_position_prefers_the_new_side(deletion_file: DiffFile) -> Non
     assert position is not None
     assert position.type is DiffLineType.UNCHANGED
     assert (position.old_line, position.new_line) == (5, 2)
+
+
+def test_find_line_position_with_the_old_side_resolves_the_removed_line(deletion_file: DiffFile) -> None:
+    """An explicit old side must beat the new-first guess, or the comment mis-anchors.
+
+    Old line 2 is the removed `beta`, and new line 2 is the surviving `epsilon`.
+    Without a side the new side wins, which puts a comment about a deleted line
+    onto an unrelated line of code.
+    """
+    position = deletion_file.find_line_position(2, side="old")
+
+    assert position is not None
+    assert position.type is DiffLineType.REMOVED
+    assert (position.old_line, position.new_line) == (2, None)
+
+
+def test_find_line_position_with_the_old_side_resolves_a_context_line_by_its_old_number(
+        deletion_file: DiffFile,
+) -> None:
+    """A context line addressed on the old side still yields both numbers, which GitLab needs."""
+    position = deletion_file.find_line_position(5, side="old")
+
+    assert position is not None
+    assert position.type is DiffLineType.UNCHANGED
+    assert (position.old_line, position.new_line) == (5, 2)
+
+
+def test_find_line_position_with_the_old_side_ignores_the_new_side_entirely(two_hunk_file: DiffFile) -> None:
+    """The ambiguity from the shift of an earlier hunk is resolved by the declared side.
+
+    Old line 128 is the removed `session.delete(entry)` while new line 128 is the
+    surviving `entry = session.get(key)`.
+    """
+    position = two_hunk_file.find_line_position(128, side="old")
+
+    assert position is not None
+    assert position.type is DiffLineType.REMOVED
+    assert (position.old_line, position.new_line) == (128, None)
+
+    assert two_hunk_file.find_line_position(128) == DiffLinePosition(DiffLineType.UNCHANGED, 127, 128)
+
+
+def test_find_line_position_with_the_new_side_never_falls_back_to_the_old_one(deletion_file: DiffFile) -> None:
+    """A number declared as new-file must not be silently reinterpreted as an old one."""
+    assert deletion_file.find_line_position(2, side="new") == DiffLinePosition(DiffLineType.UNCHANGED, 5, 2)
+    assert deletion_file.find_line_position(3, side="new") is None
+
+
+def test_find_line_position_with_a_side_returns_none_for_an_unknown_line(deletion_file: DiffFile) -> None:
+    """A declared side does not invent a position for a line outside every hunk."""
+    assert deletion_file.find_line_position(500, side="old") is None
+    assert deletion_file.find_line_position(500, side="new") is None
 
 
 def test_find_line_position_returns_none_for_unknown_line(two_hunk_file: DiffFile) -> None:

--- a/ai_review/tests/suites/libs/diff/test_parser.py
+++ b/ai_review/tests/suites/libs/diff/test_parser.py
@@ -139,3 +139,61 @@ def test_parse_preserves_standalone_carriage_return_inside_diff_record() -> None
     ]
     assert len(hunk.orig_range.lines) == hunk.orig_range.length == 1
     assert len(hunk.new_range.lines) == hunk.new_range.length == 1
+
+
+def test_parse_diff_without_file_header() -> None:
+    """Should parse a bare unified diff body, as returned by the GitLab changes API."""
+    raw_diff = """@@ -1,2 +1,2 @@
+-old line
++new line
+ kept line
+"""
+    file = parse_and_get_file(raw_diff)
+
+    assert file.mode == FileMode.MODIFIED
+    assert file.orig_name == ""
+    assert file.new_name == ""
+    assert len(file.hunks) == 1
+
+    hunk = file.hunks[0]
+    assert [line.content for line in hunk.lines] == ["old line", "new line", "kept line"]
+    assert [line.type for line in hunk.lines] == [
+        DiffLineType.REMOVED,
+        DiffLineType.ADDED,
+        DiffLineType.UNCHANGED,
+    ]
+
+
+def test_parse_multiple_hunks_tracks_independent_line_numbers() -> None:
+    """Should number each hunk from its own header, so a shift in one hunk does not leak."""
+    raw_diff = """diff --git a/x b/x
+index 6666666..7777777 100644
+--- a/x
++++ b/x
+@@ -80,4 +80,5 @@
+ class Store:
+     def __init__(self, session):
++        self.cache = {}
+     def get(self, key):
+         return self.session.get(key)
+@@ -126,4 +127,5 @@
+ def remove(session, key):
+     entry = session.get(key)
+-    session.delete(entry)
++    session.mark_deleted(entry)
++    session.flush()
+     session.commit()
+"""
+    file = parse_and_get_file(raw_diff)
+
+    assert len(file.hunks) == 2
+
+    first, second = file.hunks
+    assert (first.orig_range.start, first.new_range.start) == (80, 80)
+    assert (second.orig_range.start, second.new_range.start) == (126, 127)
+
+    assert file.added_line_numbers() == {82, 129, 130}
+    assert file.removed_line_numbers() == {128}
+
+    assert [line.number for line in second.new_range.lines] == [127, 128, 129, 130, 131]
+    assert [line.number for line in second.orig_range.lines] == [126, 127, 128, 129]

--- a/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
+++ b/ai_review/tests/suites/services/review/gateway/test_review_comment_gateway.py
@@ -238,6 +238,32 @@ async def test_process_inline_comment_happy_path(
 
 
 @pytest.mark.asyncio
+async def test_process_inline_comment_forwards_the_declared_side(
+        fake_vcs_client: FakeVCSClient,
+        review_comment_gateway: ReviewCommentGateway,
+):
+    """A side the caller resolved is worthless unless it reaches the provider."""
+    comment = InlineCommentSchema(file="f.py", line=1, message="AI inline comment", side="old")
+    await review_comment_gateway.process_inline_comment(comment)
+
+    call = next(call for call in fake_vcs_client.calls if call[0] == "create_inline_comment")
+    assert call[2] == {"side": "old"}
+
+
+@pytest.mark.asyncio
+async def test_process_inline_comment_forwards_no_side_when_none_was_declared(
+        fake_vcs_client: FakeVCSClient,
+        review_comment_gateway: ReviewCommentGateway,
+):
+    """The LLM review path has no side to declare, so the provider must keep guessing."""
+    comment = InlineCommentSchema(file="f.py", line=1, message="AI inline comment")
+    await review_comment_gateway.process_inline_comment(comment)
+
+    call = next(call for call in fake_vcs_client.calls if call[0] == "create_inline_comment")
+    assert call[2] == {"side": None}
+
+
+@pytest.mark.asyncio
 async def test_process_inline_comment_error_fallback(
         capsys: pytest.CaptureFixture,
         fake_vcs_client: FakeVCSClient,
@@ -246,7 +272,7 @@ async def test_process_inline_comment_error_fallback(
 ):
     """Should fall back to inline fallback comment when inline comment fails."""
 
-    async def failing_create_inline_comment(file: str, line: int, message: str):
+    async def failing_create_inline_comment(file: str, line: int, message: str, side: str | None = None):
         raise RuntimeError("Failed to post inline")
 
     fake_vcs_client.create_inline_comment = failing_create_inline_comment
@@ -379,7 +405,7 @@ async def test_process_inline_comment_error_no_fallback_when_disabled(
     """Should NOT fall back to summary comment when inline fallback is disabled."""
     monkeypatch.setattr(settings.review, "inline_comment_fallback", False)
 
-    async def failing_create_inline_comment(file: str, line: int, message: str):
+    async def failing_create_inline_comment(file: str, line: int, message: str, side: str | None = None):
         raise RuntimeError("Failed to post inline")
 
     fake_vcs_client.create_inline_comment = failing_create_inline_comment

--- a/ai_review/tests/suites/services/review/internal/inline/test_schema.py
+++ b/ai_review/tests/suites/services/review/internal/inline/test_schema.py
@@ -46,6 +46,39 @@ def test_fallback_body(monkeypatch: pytest.MonkeyPatch):
     assert comment.fallback_body.startswith("**a.py:42** — missing check")
 
 
+def test_side_is_unset_by_default():
+    """ai-review's own review path emits bare line numbers, so no side is claimed."""
+    assert InlineCommentSchema(file="a.py", line=1, message="msg").side is None
+
+
+def test_side_can_be_declared():
+    """A caller that resolved the line against the diff carries the side it found."""
+    assert InlineCommentSchema(file="a.py", line=1, message="msg", side="old").side == "old"
+
+
+def test_fallback_body_marks_a_comment_on_the_old_side():
+    """The fallback is read by a human, who would otherwise look up the wrong line."""
+    comment = InlineCommentSchema(file="a.py", line=42, message="deleted the guard", side="old")
+
+    assert comment.fallback_body.startswith("**a.py:42 (old side)** — deleted the guard")
+
+
+def test_fallback_body_is_unchanged_for_the_new_side():
+    """Only the old side needs the marker, so the usual output must not change."""
+    for side in (None, "new"):
+        comment = InlineCommentSchema(file="a.py", line=42, message="missing check", side=side)
+        assert comment.fallback_body == "**a.py:42** — missing check"
+
+
+def test_dedup_key_differs_on_side():
+    """The two sides of one line number are two different lines, not a duplicate."""
+    old_side = InlineCommentSchema(file="a.py", line=1, message="msg", side="old")
+    new_side = InlineCommentSchema(file="a.py", line=1, message="msg", side="new")
+
+    assert old_side.dedup_key != new_side.dedup_key
+    assert len(InlineCommentListSchema(root=[old_side, new_side]).dedupe().root) == 2
+
+
 def test_dedup_key_differs_on_message_and_suggestion():
     c1 = InlineCommentSchema(file="a.py", line=1, message="msg one")
     c2 = InlineCommentSchema(file="a.py", line=1, message="msg one", suggestion="x = 1")

--- a/ai_review/tests/suites/services/vcs/gitlab/test_client.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_client.py
@@ -660,6 +660,75 @@ async def test_create_draft_inline_comment_sends_paired_position_for_context_lin
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("gitlab_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_inline_comment_anchors_a_removed_line_declared_on_the_old_side(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should address the old side when the caller declares it, not the colliding new line.
+
+    Old line 128 is the removed `session.delete(entry)`; new line 128 is the
+    surviving `entry = session.get(key)`. Sending new_line=128 would put the
+    comment on a line the finding is not about.
+    """
+    await gitlab_vcs_client.create_inline_comment(
+        file="src/db.py", line=128, message="Removed the delete", side="old"
+    )
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_discussion"
+    )
+    position = call["position"]
+
+    assert position.old_path == "src/db.py"
+    assert position.new_path == "src/db.py"
+    assert position.old_line == 128
+    assert position.new_line is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_draft_inline_comment_anchors_a_removed_line_declared_on_the_old_side(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should carry the declared side into the draft note as well, where a bad position is lost silently."""
+    await gitlab_vcs_client.create_inline_comment(
+        file="src/db.py", line=128, message="Removed the delete", side="old"
+    )
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_draft_note"
+    )
+    position = call["position"]
+
+    assert position.old_path == "src/db.py"
+    assert position.old_line == 128
+    assert position.new_line is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_inline_comment_without_a_side_still_resolves_against_the_new_file(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should leave the LLM review path, which sends bare line numbers, exactly as it was."""
+    await gitlab_vcs_client.create_inline_comment(file="src/db.py", line=128, message="Context finding")
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_discussion"
+    )
+    position = call["position"]
+
+    assert position.old_line == 127
+    assert position.new_line == 128
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config", "gitlab_two_hunk_changes")
 async def test_create_inline_comment_omits_old_line_for_added_line(
         gitlab_vcs_client: GitLabVCSClient,
         fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,

--- a/ai_review/tests/suites/services/vcs/gitlab/test_client.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_client.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from ai_review.clients.gitlab.mr.schema.draft_notes import GitLabDraftNoteSchema
+from ai_review.clients.gitlab.mr.schema.changes import GitLabMRChangeSchema
 from ai_review.services.vcs.gitlab.client import GitLabVCSClient
 from ai_review.services.vcs.types import (
     ReviewInfoSchema,
@@ -585,3 +586,113 @@ async def test_create_inline_comment_does_not_retry_purge_within_run_after_failu
     assert called_methods.count("get_draft_notes") == 1
     assert called_methods.count("create_draft_note") == 2
     assert gitlab_vcs_client.pending_comments == 2
+
+
+# Two hunks where the first inserts one line, so line 131 on the new side is
+# line 129 on the old side. A comment there is the case GitLab rejects with
+# `line_code can't be blank, must be a valid line code`.
+TWO_HUNK_DIFF = """@@ -80,4 +80,5 @@
+ class Store:
+     def __init__(self, session):
++        self.cache = {}
+     def get(self, key):
+         return self.session.get(key)
+@@ -126,4 +127,5 @@
+ def remove(session, key):
+     entry = session.get(key)
+-    session.delete(entry)
++    session.mark_deleted(entry)
++    session.flush()
+     session.commit()
+"""
+
+
+@pytest.fixture
+def gitlab_two_hunk_changes(
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+) -> None:
+    fake_gitlab_merge_requests_http_client.changes = [
+        GitLabMRChangeSchema(diff=TWO_HUNK_DIFF, old_path="src/db.py", new_path="src/db.py")
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_inline_comment_sends_paired_position_for_context_line(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should send old_path and old_line for a discussion anchored to a context line."""
+    await gitlab_vcs_client.create_inline_comment(file="src/db.py", line=131, message="Context finding")
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_discussion"
+    )
+    position = call["position"]
+
+    assert position.new_path == "src/db.py"
+    assert position.new_line == 131
+    assert position.old_path == "src/db.py"
+    assert position.old_line == 129
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_batch_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_draft_inline_comment_sends_paired_position_for_context_line(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should send old_path and old_line for a draft note anchored to a context line."""
+    await gitlab_vcs_client.create_inline_comment(file="src/db.py", line=131, message="Context finding")
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_draft_note"
+    )
+    position = call["position"]
+
+    assert position.new_path == "src/db.py"
+    assert position.new_line == 131
+    assert position.old_path == "src/db.py"
+    assert position.old_line == 129
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config", "gitlab_two_hunk_changes")
+async def test_create_inline_comment_omits_old_line_for_added_line(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should leave old_line unset for an added line, which GitLab already accepted."""
+    await gitlab_vcs_client.create_inline_comment(file="src/db.py", line=129, message="Added finding")
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_discussion"
+    )
+    position = call["position"]
+
+    assert position.new_line == 129
+    assert position.old_line is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("gitlab_http_client_config")
+async def test_create_inline_comment_keeps_new_line_only_for_unknown_file(
+        gitlab_vcs_client: GitLabVCSClient,
+        fake_gitlab_merge_requests_http_client: FakeGitLabMergeRequestsHTTPClient,
+):
+    """Should keep the previous payload when the file is absent from the MR changes."""
+    await gitlab_vcs_client.create_inline_comment(file="src/absent.py", line=12, message="Finding")
+
+    call = next(
+        args for name, args in fake_gitlab_merge_requests_http_client.calls
+        if name == "create_discussion"
+    )
+    position = call["position"]
+
+    assert position.new_path == "src/absent.py"
+    assert position.new_line == 12
+    assert position.old_path is None
+    assert position.old_line is None

--- a/ai_review/tests/suites/services/vcs/gitlab/test_position.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_position.py
@@ -97,6 +97,58 @@ def test_build_inline_position_omits_the_new_line_for_a_removed_line() -> None:
     assert position.new_line is None
 
 
+def test_build_inline_position_anchors_a_removed_line_declared_on_the_old_side() -> None:
+    """A declared old side must beat the new-first guess, or GitLab anchors the wrong line.
+
+    Old line 128 is the removed `session.delete(entry)`; new line 128 is the
+    surviving `entry = session.get(key)`. Both readings are possible, so the
+    guess picks the wrong one and reports nothing.
+    """
+    position = build_inline_position(file="src/db.py", line=128, side="old", diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path == "src/db.py"
+    assert position.new_path == "src/db.py"
+    assert position.old_line == 128
+    assert position.new_line is None
+
+
+def test_build_inline_position_without_a_side_keeps_preferring_the_new_line() -> None:
+    """ai-review's own path sends bare numbers, so its behaviour must not change."""
+    position = build_inline_position(file="src/db.py", line=128, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_line == 127
+    assert position.new_line == 128
+
+
+def test_build_inline_position_pairs_a_context_line_declared_on_the_old_side() -> None:
+    """Old line 126 is a context line the guess cannot resolve at all, having no new-side twin."""
+    position = build_inline_position(file="src/db.py", line=126, side="old", diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_line == 126
+    assert position.new_line == 127
+
+    unresolved = build_inline_position(file="src/db.py", line=126, diff_refs=DIFF_REFS, changes=CHANGES)
+    assert (unresolved.old_path, unresolved.old_line, unresolved.new_line) == (None, None, 126)
+
+
+def test_build_inline_position_omits_the_old_line_for_an_added_line_declared_on_the_new_side() -> None:
+    """An added line declared on the new side still carries no old_line."""
+    position = build_inline_position(file="src/db.py", line=129, side="new", diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path == "src/db.py"
+    assert position.old_line is None
+    assert position.new_line == 129
+
+
+def test_build_inline_position_keeps_the_new_line_when_the_declared_new_side_has_no_such_line() -> None:
+    """A number declared new-file is not reinterpreted as an old one; it stays unresolved."""
+    position = build_inline_position(file="src/db.py", line=126, side="new", diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path is None
+    assert position.old_line is None
+    assert position.new_line == 126
+
+
 def test_build_inline_position_uses_both_paths_of_a_rename() -> None:
     """Should carry the pre- and post-rename paths, which GitLab uses to locate the diff file."""
     changes = [GitLabMRChangeSchema(diff=TWO_HUNK_DIFF, old_path="src/old.py", new_path="src/new.py")]

--- a/ai_review/tests/suites/services/vcs/gitlab/test_position.py
+++ b/ai_review/tests/suites/services/vcs/gitlab/test_position.py
@@ -1,0 +1,183 @@
+from ai_review.clients.gitlab.mr.schema.changes import GitLabDiffRefsSchema, GitLabMRChangeSchema
+from ai_review.services.vcs.gitlab.position import build_inline_position, find_change
+
+# Two hunks where the first inserts one line, so every line number in the second
+# hunk differs between the old and the new file.
+TWO_HUNK_DIFF = """@@ -80,4 +80,5 @@
+ class Store:
+     def __init__(self, session):
++        self.cache = {}
+     def get(self, key):
+         return self.session.get(key)
+@@ -126,4 +127,5 @@
+ def remove(session, key):
+     entry = session.get(key)
+-    session.delete(entry)
++    session.mark_deleted(entry)
++    session.flush()
+     session.commit()
+"""
+
+DIFF_REFS = GitLabDiffRefsSchema(base_sha="base-sha", head_sha="head-sha", start_sha="start-sha")
+
+CHANGES = [
+    GitLabMRChangeSchema(diff=TWO_HUNK_DIFF, old_path="src/db.py", new_path="src/db.py"),
+    GitLabMRChangeSchema(diff="@@ -1,0 +1,1 @@\n+first", old_path="src/new.py", new_path="src/new.py"),
+]
+
+
+# ---------- find_change ----------
+
+def test_find_change_matches_the_new_path() -> None:
+    """Should find the change entry describing the file."""
+    assert find_change(CHANGES, "src/db.py") is CHANGES[0]
+
+
+def test_find_change_matches_the_old_path_of_a_rename() -> None:
+    """Should also match on the pre-rename path."""
+    changes = [GitLabMRChangeSchema(diff=TWO_HUNK_DIFF, old_path="src/old.py", new_path="src/new.py")]
+
+    assert find_change(changes, "src/old.py") is changes[0]
+
+
+def test_find_change_returns_none_for_unknown_file() -> None:
+    """Should return nothing when the file is not part of the MR."""
+    assert find_change(CHANGES, "src/absent.py") is None
+
+
+# ---------- build_inline_position ----------
+
+def test_build_inline_position_pairs_a_context_line() -> None:
+    """Should send both line numbers for an unchanged line, which GitLab needs to resolve it."""
+    position = build_inline_position(file="src/db.py", line=131, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.position_type == "text"
+    assert position.base_sha == "base-sha"
+    assert position.head_sha == "head-sha"
+    assert position.start_sha == "start-sha"
+    assert position.old_path == "src/db.py"
+    assert position.new_path == "src/db.py"
+    assert position.old_line == 129
+    assert position.new_line == 131
+
+
+def test_build_inline_position_pairs_a_context_line_in_the_first_hunk() -> None:
+    """Should keep the two sides in step before any shift has accumulated."""
+    position = build_inline_position(file="src/db.py", line=81, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_line == 81
+    assert position.new_line == 81
+
+
+def test_build_inline_position_omits_the_old_line_for_an_added_line() -> None:
+    """An added line has no counterpart in the old file, so old_line must stay unset."""
+    position = build_inline_position(file="src/db.py", line=129, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path == "src/db.py"
+    assert position.new_path == "src/db.py"
+    assert position.old_line is None
+    assert position.new_line == 129
+
+
+def test_build_inline_position_omits_the_new_line_for_a_removed_line() -> None:
+    """A removed line exists only in the old file, so new_line must be dropped."""
+    changes = [
+        GitLabMRChangeSchema(
+            diff="@@ -1,5 +1,2 @@\n alpha\n-beta\n-gamma\n-delta\n epsilon\n",
+            old_path="src/list.py",
+            new_path="src/list.py",
+        )
+    ]
+
+    position = build_inline_position(file="src/list.py", line=3, diff_refs=DIFF_REFS, changes=changes)
+
+    assert position.old_path == "src/list.py"
+    assert position.new_path == "src/list.py"
+    assert position.old_line == 3
+    assert position.new_line is None
+
+
+def test_build_inline_position_uses_both_paths_of_a_rename() -> None:
+    """Should carry the pre- and post-rename paths, which GitLab uses to locate the diff file."""
+    changes = [GitLabMRChangeSchema(diff=TWO_HUNK_DIFF, old_path="src/old.py", new_path="src/new.py")]
+
+    position = build_inline_position(file="src/new.py", line=131, diff_refs=DIFF_REFS, changes=changes)
+
+    assert position.old_path == "src/old.py"
+    assert position.new_path == "src/new.py"
+    assert position.old_line == 129
+    assert position.new_line == 131
+
+
+def test_build_inline_position_keeps_the_new_line_when_the_line_is_not_in_the_diff() -> None:
+    """An unresolvable line keeps the payload unchanged, so the inline fallback still applies."""
+    position = build_inline_position(file="src/db.py", line=900, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path is None
+    assert position.new_path == "src/db.py"
+    assert position.old_line is None
+    assert position.new_line == 900
+
+
+def test_build_inline_position_keeps_the_new_line_when_the_file_is_not_in_the_changes() -> None:
+    """A file GitLab did not report keeps the payload unchanged."""
+    position = build_inline_position(file="src/absent.py", line=12, diff_refs=DIFF_REFS, changes=CHANGES)
+
+    assert position.old_path is None
+    assert position.new_path == "src/absent.py"
+    assert position.old_line is None
+    assert position.new_line == 12
+
+
+def test_build_inline_position_keeps_the_new_line_when_the_diff_is_missing() -> None:
+    """GitLab omits the diff body for large files, which must not break comment creation."""
+    changes = [GitLabMRChangeSchema(diff=None, old_path="src/big.py", new_path="src/big.py")]
+
+    position = build_inline_position(file="src/big.py", line=12, diff_refs=DIFF_REFS, changes=changes)
+
+    assert position.old_path is None
+    assert position.new_path == "src/big.py"
+    assert position.old_line is None
+    assert position.new_line == 12
+
+
+def test_build_inline_position_keeps_the_new_line_when_the_diff_does_not_parse() -> None:
+    """A diff body we cannot parse must degrade, not raise."""
+    changes = [
+        GitLabMRChangeSchema(diff="@@ not a hunk header @@\n+x\n", old_path="src/odd.py", new_path="src/odd.py")
+    ]
+
+    position = build_inline_position(file="src/odd.py", line=1, diff_refs=DIFF_REFS, changes=changes)
+
+    assert position.old_path is None
+    assert position.new_path == "src/odd.py"
+    assert position.old_line is None
+    assert position.new_line == 1
+
+
+def test_build_inline_position_keeps_the_new_line_for_a_diff_without_hunks() -> None:
+    """GitLab reports binary files without any hunk, so there is nothing to resolve against."""
+    changes = [
+        GitLabMRChangeSchema(
+            diff="Binary files a/logo.png and b/logo.png differ\n",
+            old_path="logo.png",
+            new_path="logo.png",
+        )
+    ]
+
+    position = build_inline_position(file="logo.png", line=1, diff_refs=DIFF_REFS, changes=changes)
+
+    assert position.old_path is None
+    assert position.new_path == "logo.png"
+    assert position.old_line is None
+    assert position.new_line == 1
+
+
+def test_build_inline_position_keeps_the_new_line_without_any_changes() -> None:
+    """An empty changes payload keeps the payload unchanged."""
+    position = build_inline_position(file="src/db.py", line=131, diff_refs=DIFF_REFS, changes=[])
+
+    assert position.old_path is None
+    assert position.new_path == "src/db.py"
+    assert position.old_line is None
+    assert position.new_line == 131


### PR DESCRIPTION
Closes #43, closes #73, closes #87.

## Problem

`GitLabVCSClient` builds every inline-comment position with `new_path` and `new_line` only. `old_path` and `old_line` stay at their `None` defaults, for every comment, on added and unchanged lines alike. Both call sites are affected — `create_inline_comment` and `create_draft_inline_comment` carried byte-identical position literals.

That is not a valid position for an unchanged line. From the [Discussions API documentation](https://docs.gitlab.com/api/discussions/), "Create a new thread in the merge request diff":

> Both `position[old_path]` and `position[new_path]` are required and must refer to the file path before and after the change.

> To create a thread on an added line (highlighted in green in the merge request diff), use `position[new_line]` and don't include `position[old_line]`.

> To create a thread on a removed line (highlighted in red in the merge request diff), use `position[old_line]` and don't include `position[new_line]`.

> To create a thread on an unchanged line, include both `position[new_line]` and `position[old_line]` for the line.

So:

| comment target | what we send today | result |
|---|---|---|
| added line | `new_line` only | correct — these have always worked |
| **unchanged line** | `new_line` only | **rejected**: `line_code can't be blank, must be a valid line code` |
| **removed line** | the old-file number, sent as `new_line` | **rejected, or silently anchored to the wrong line** |

This is the error reported in #43, #73 and #87. Those issues were closed on the reading that the model had pointed at a line outside the diff, and that the inline fallback handles it. That does happen — but it is not the only cause, and the other cause is ours: a line that *is* in the diff and *is* a legitimate review target gets rejected because we send only half of its address.

Removed lines are worse than the table suggests. `render_unified` labels a removed line with its **old-file** number (`-{old}: …`), so when the model comments on one, that old number arrives as `line` and we send it as `new_line`. `ONLY_REMOVED` and `FULL_FILE_PREVIOUS` make removed lines the primary review target, so this is reachable by configuration, not only by model error.

## Why this is easy to miss with `batch_comments: true`

With batching enabled the failure is **silent data loss, not a fallback**.

`POST /draft_notes` returns **201 Created** — GitLab does not validate the position when the draft is created. No exception reaches `ReviewCommentGateway.process_inline_comment`, so its `except` branch never runs and `inline_comment_fallback` never fires. The rejection arrives later as a **500 on `POST /draft_notes/bulk_publish`**, raised inside `ReviewCommentGateway.finalize()`, whose only handler is `except Exception: logger.exception(...)`. There is no per-comment recovery at that point, and the exception is swallowed. GitLab publishes the valid subset; the malformed notes are destroyed, and nothing in the log identifies which findings were lost.

In the non-batched path the same position 400s immediately, the per-comment `except` fires, the fallback runs, and the finding still reaches the reviewer as a general comment — which is why this looked like nothing worse than noisy logs.

The practical effect is skewed against the findings that matter most: a bugfix mostly *modifies* existing code, so comments about the change itself anchor to unchanged lines, while purely additive files (new tests, CI config) anchor to added lines and always survive.

## Fix

Resolve the line against the diff GitLab already returns in the `GET …/merge_requests/:iid/changes` response that **both methods already fetch**, and send both sides of the position. No new HTTP request.

Four commits:

1. **`fix(diff): parse unified diff bodies that carry no file header`** — `DiffParser.parse` only started a `DiffFile` on a line beginning with `diff `, so the bare body GitLab returns for each `changes[]` entry, which starts at `@@`, raised `AttributeError: 'NoneType' object has no attribute 'hunks'`. Now an implicit file is started. Well-formed `git diff` input is unaffected. This commit also adds the suite's first multi-hunk parser test: every existing parser test covered a single hunk, so nothing verified that a hunk is numbered from its own header and that a shift introduced by an earlier hunk does not leak into a later one.

2. **`feat(diff): resolve paired old/new line numbers for a diff line`** — `DiffFile.line_positions()` pairs both numbers for every line of every hunk, and `DiffFile.find_line_position()` resolves a bare line number back to that pair. The parser already tracked both counters; nothing exposed the pair. `added_line_numbers()` and `removed_line_numbers()` each return one side, and `render_unified` recomputes the counters privately in order to print one number per line.

3. **`fix(gitlab): send old_line/old_path for inline comments on context lines`** — a new `ai_review/services/vcs/gitlab/position.py` builds the payload, and both call sites delegate to it, which also removes the duplicated literal.

4. **`chore(diff): satisfy the current ruff release`** — `PIE810` for the chained `startswith` introduced in commit 1, and `UP006`/`UP035` for the pre-existing `typing.List` in `ai_review/libs/diff/models.py`. No behavior change. Happy to drop this commit if you would rather keep it out of a bugfix branch.

Resolution is best effort. When the file is absent from the `changes` payload, when GitLab omitted the diff body (large or binary files), or when the body does not parse, the position keeps **exactly** the fields it carried before. Those comments take the same path through `inline_comment_fallback` as they do today, so no path that currently succeeds changes behavior.

## Scope of the removed-line improvement

Be aware this is an improvement, not a complete fix for removed lines.

`find_line_position` reads the incoming number as a new-file line first — that preserves the meaning `create_inline_comment(file, line, message)` has always had, and it is correct for every mode that numbers lines on the new side. Only if no new-file line matches does it read the number as the old-file line of a removed line. So a comment on a removed line is resolved correctly **only when that line's old-file number matches no line on the new side of the same file's diff**. When both readings are possible, the new side wins, which is the same line the current code targets. See "Known limitation" below for why the number is ambiguous in the first place.

## Architecture notes

- **Nothing added to `VCSClientProtocol`, no new configuration key.** The GitLab specifics live in `ai_review/services/vcs/gitlab/`. The other five providers carry nothing.
- **The line mapping is provider-agnostic**, so it lives in `ai_review/libs/diff/` beside `added_line_numbers()` and `removed_line_numbers()`. It knows nothing about GitLab.
- **The method stays self-sufficient.** The change entry is resolved inside the call, from the response that same call made. No hidden state, no dependency on call order. This follows the shape you asked for in #90.
- **Why not `line_code`, as #73 proposed:** the documented single-line flow above never mentions `line_code`, and the documented format `<SHA>_<old>_<new>` embeds the very numbers that were missing. GitLab derives the line code from the position, which is exactly what fails when the position is incomplete — so supplying the line numbers is the fix, and supplying a hand-computed `line_code` would at best duplicate it.
- **Possible follow-up, deliberately not in this PR:** `render_unified` recomputes per-hunk old/new counters that `DiffFile.line_positions()` now also computes. Folding the renderer onto the new helper would remove the duplication, but it touches the rendering of every review mode, which is more risk than a bugfix should carry. Happy to do it separately if you want it.

## Reproduction

No LLM needed. Use any merge request that **modifies** an existing file, and pick a line the diff did *not* add.

```bash
GITLAB=https://gitlab.example.com
TOKEN=…            # api scope
PROJECT=…          # project id
MR=…               # merge request iid

# 1. Get the diff refs and the file's diff, then pick an unchanged line inside a hunk.
curl -s --header "PRIVATE-TOKEN: $TOKEN" \
  "$GITLAB/api/v4/projects/$PROJECT/merge_requests/$MR/changes" \
  | jq '{diff_refs, path: .changes[0].new_path, diff: .changes[0].diff}'
```

Suppose the first hunk is `@@ -80,4 +80,5 @@` and inserts one line, and the second is `@@ -126,4 +127,5 @@`. Then new line `131` is an unchanged line whose old-file number is `129`.

```bash
# 2. What ai-review sends today -> 400
curl -s -X POST --header "PRIVATE-TOKEN: $TOKEN" \
  --header "Content-Type: application/json" \
  "$GITLAB/api/v4/projects/$PROJECT/merge_requests/$MR/discussions" \
  --data '{
    "body": "probe: new_line only",
    "position": {
      "position_type": "text",
      "base_sha": "<base_sha>", "head_sha": "<head_sha>", "start_sha": "<start_sha>",
      "new_path": "<path>",
      "new_line": 131
    }}'
# {"message":"400 Bad request - Note {:line_code=>[\"can't be blank\", \"must be a valid line code\"]}"}

# 3. The same line, with the old side filled in -> 201 Created
curl -s -X POST --header "PRIVATE-TOKEN: $TOKEN" \
  --header "Content-Type: application/json" \
  "$GITLAB/api/v4/projects/$PROJECT/merge_requests/$MR/discussions" \
  --data '{
    "body": "probe: paired position",
    "position": {
      "position_type": "text",
      "base_sha": "<base_sha>", "head_sha": "<head_sha>", "start_sha": "<start_sha>",
      "old_path": "<path>", "new_path": "<path>",
      "old_line": 129,      "new_line": 131
    }}'
```

To see the silent-loss variant, send request 2 to `…/draft_notes` instead. It returns **201**, and `POST …/draft_notes/bulk_publish` afterwards returns **500** and publishes only the valid notes.

The same reproduction runs offline in the test suite:

```
AI_REVIEW_CONFIG_FILE_YAML=./ai_review/tests/configs/config-test.yaml \
  pytest ai_review/tests/suites/services/vcs/gitlab/test_client.py -k paired
```

That selects two tests, one per call site. Revert commit 3 and both fail with `old_path` and `old_line` still `None`.

## Tests

28 new tests. No existing test was modified. The suite goes from 757 to 785 passing, and each commit passes the full suite on its own (759, 767, 785, 785).

- `ai_review/tests/suites/libs/diff/test_parser.py` — `test_parse_diff_without_file_header`, and `test_parse_multiple_hunks_tracks_independent_line_numbers`, the first multi-hunk parser test in the suite.
- `ai_review/tests/suites/libs/diff/test_models.py` — 8 tests for the mapping, including `test_find_line_position_across_hunks_accounts_for_shift`, where a context line's old and new numbers differ (129 against 131). That is the guard against an `old_line = new_line` shortcut, and `test_find_line_position_prefers_the_new_side` pins the resolution order.
- `ai_review/tests/suites/services/vcs/gitlab/test_position.py` (new) — 14 tests: added, unchanged and removed lines, renames, a line that is not in the diff, a file that is not in `changes`, an omitted diff body, a binary file, an unparseable diff, and an empty `changes` list.
- `ai_review/tests/suites/services/vcs/gitlab/test_client.py` — 4 tests: both call sites end to end, that an added line still sends no `old_line`, and that an unresolvable file keeps the previous payload so the inline fallback is untouched.

## Known limitation, out of scope here

`render_unified` numbers added and unchanged lines on the new side and removed lines on the old side, so two different lines can be rendered with the same number. In `FULL_FILE_DIFF`, the default mode:

```
 128:     entry = session.get(key)
-128:     session.delete(entry) # removed
```

A bare line number therefore cannot always say which side it means, and `create_inline_comment(file, line, message)` receives nothing else. That is a shared-protocol limitation rather than a GitLab one, and it is what bounds the removed-line improvement described above. I will open a separate issue to discuss it, with the options and what each one costs providers that do not need it. **That discussion should not hold this PR:** this patch is a strict improvement under the current protocol and does not depend on how the ambiguity is eventually resolved.
