### PR TITLE
fix(agent): never promote an unparseable action to the final review

### DIFF
--- a/ai_review/services/agent/loop/schema.py
+++ b/ai_review/services/agent/loop/schema.py
@@ -44,7 +44,7 @@ class AgentStepSchema(BaseModel):
 
 
 class AgentTraceSchema(BaseModel):
-    step: AgentStepSchema
+    step: AgentStepSchema | None = None
     warning: str | None = None
     iteration: int
     raw_output: str

--- a/ai_review/services/agent/loop/service.py
+++ b/ai_review/services/agent/loop/service.py
@@ -1,3 +1,5 @@
+import re
+
 from ai_review.config import settings
 from ai_review.libs.llm.output_json_parser import LLMOutputJSONParser
 from ai_review.libs.logger import get_logger
@@ -13,6 +15,29 @@ from ai_review.services.llm.types import LLMClientProtocol, ChatResultSchema
 from ai_review.services.prompt.types import PromptServiceProtocol
 
 logger = get_logger("AGENT_LOOP_SERVICE")
+
+AGENT_ACTION_ENVELOPE_RE = re.compile(
+    rf"""["']action["']\s*:\s*["']({"|".join(AgentAction)})["']""",
+    re.IGNORECASE,
+)
+PROTOCOL_RETRY_WARNING = (
+    "Invalid response discarded: it carried an agent action but was not a single valid JSON object. "
+    "Respond with exactly one JSON object and nothing else: "
+    '{"action": "TOOL_CALL", "command": "<single shell command>"} '
+    'or {"action": "FINAL", "content": "<complete answer as a string>"}. '
+    'Every quote inside a JSON string value must be escaped as \\".'
+)
+MAX_PROTOCOL_VIOLATIONS = 2
+
+
+def is_attempted_action(output: str) -> bool:
+    """Whether unparseable model output still carries the agent protocol envelope.
+
+    Such output is a protocol violation — an attempted TOOL_CALL or FINAL — and must never be
+    promoted to the final review. Output without the envelope is a genuine final answer
+    (plain Markdown, or a JSON array of inline comments) and is returned to the caller as is.
+    """
+    return bool(AGENT_ACTION_ENVELOPE_RE.search(output or ""))
 
 
 class AgentLoopService(AgentLoopServiceProtocol):
@@ -32,11 +57,14 @@ class AgentLoopService(AgentLoopServiceProtocol):
         self.traces: list[AgentTraceSchema] = []
         self.signatures: set[str] = set()
         self.context_used = 0
+        self.protocol_violations = 0
+        self.max_protocol_violations = MAX_PROTOCOL_VIOLATIONS
 
     def clear(self):
         self.traces = []
         self.signatures = set()
         self.context_used = 0
+        self.protocol_violations = 0
         logger.debug("Agent loop state cleared")
 
     async def run_step(self, step: AgentStepSchema, chat: ChatResultSchema, iteration: int) -> AgentTraceSchema:
@@ -97,6 +125,12 @@ class AgentLoopService(AgentLoopServiceProtocol):
             f"parsed_as_final={bool(fallback_step and fallback_step.action.is_final)}"
         )
 
+        if fallback_step is None and is_attempted_action(fallback_text):
+            logger.warning(
+                "Forced FINAL response is an unparseable action too; "
+                "returning the raw model output as a last resort"
+            )
+
         final_text = (
             fallback_step.content
             if fallback_step and fallback_step.action.is_final
@@ -152,6 +186,31 @@ class AgentLoopService(AgentLoopServiceProtocol):
             step: AgentStepSchema | None = self.parser.parse_output(result.text)
             if step is None:
                 fallback_text = result.text or ""
+
+                if is_attempted_action(fallback_text):
+                    self.protocol_violations += 1
+                    logger.warning(
+                        f"Agent loop iteration {iteration} returned an unparseable action "
+                        f"({self.protocol_violations}/{self.max_protocol_violations} tolerated); "
+                        f"discarding it instead of using it as the final answer"
+                    )
+                    self.traces.append(
+                        AgentTraceSchema(
+                            warning=PROTOCOL_RETRY_WARNING,
+                            iteration=iteration,
+                            raw_output=fallback_text,
+                            total_tokens=result.total_tokens,
+                            prompt_tokens=result.prompt_tokens,
+                            completion_tokens=result.completion_tokens,
+                        )
+                    )
+
+                    if self.protocol_violations <= self.max_protocol_violations:
+                        continue
+
+                    logger.info("Too many unparseable actions; switching to force-final flow")
+                    break
+
                 logger.info(f"Agent loop iteration {iteration} returned unstructured response; stopping")
                 self.traces.append(
                     AgentTraceSchema(

--- a/ai_review/services/prompt/tools.py
+++ b/ai_review/services/prompt/tools.py
@@ -49,13 +49,13 @@ def normalize_prompt(text: str) -> str:
 def format_trace(trace: AgentTraceSchema) -> str:
     lines = [f"Iteration: {trace.iteration}"]
 
-    if trace.step.command:
+    if trace.step and trace.step.command:
         lines.append(f"Command: {trace.step.command}")
 
     if trace.tool_output:
         lines.append(f"Tool output: {trace.tool_output}")
 
-    if trace.step.content:
+    if trace.step and trace.step.content:
         lines.append(f"Content: {trace.step.content}")
 
     if trace.warning:

--- a/ai_review/tests/suites/services/agent/loop/test_service.py
+++ b/ai_review/tests/suites/services/agent/loop/test_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ai_review.services.agent.loop.service import AgentLoopService
+from ai_review.services.agent.loop.service import AgentLoopService, is_attempted_action
 from ai_review.services.llm.types import ChatResultSchema
 from ai_review.tests.fixtures.services.agent.tool import FakeAgentToolService
 from ai_review.tests.fixtures.services.llm import FakeLLMClient
@@ -19,6 +19,15 @@ def sequence_chat_results(outputs: list[ChatResultSchema]):
         return outputs.pop(0)
 
     return chat
+
+
+MALFORMED_TOOL_CALL = '{"action":"TOOL_CALL","command":"git grep -n -i -l "migration" -- docs"}'
+REASONING_PREFIXED_TOOL_CALL = '</think>{"action":"TOOL_CALL","command":"cat modules/Sample.java"}'
+PROSE_WRAPPED_TOOL_CALL = (
+    'Let me examine the key files first.{"action":"TOOL_CALL","command":"cat modules/Sample.java"}'
+)
+MARKDOWN_SUMMARY = "## Summary\n\n- The change looks correct.\n\n```python\nprint(1)\n```\n"
+INLINE_COMMENTS_JSON = '[{"file":"a.py","line":10,"message":"Unused import","suggestion":null}]'
 
 
 @pytest.mark.asyncio
@@ -325,3 +334,234 @@ async def test_run_persists_llm_tokens_in_traces(
     assert result.prompt_tokens == 15
     assert result.completion_tokens == 30
     assert result.total_tokens == 45
+
+
+@pytest.mark.parametrize(
+    "output, expected",
+    [
+        (MALFORMED_TOOL_CALL, True),
+        (REASONING_PREFIXED_TOOL_CALL, True),
+        (PROSE_WRAPPED_TOOL_CALL, True),
+        ('{"action": "final", "content": "oops', True),
+        (MARKDOWN_SUMMARY, False),
+        (INLINE_COMMENTS_JSON, False),
+        ("", False),
+        ("The action taken by the FINAL migration is unclear", False),
+    ],
+)
+def test_is_attempted_action_detects_the_protocol_envelope(output: str, expected: bool) -> None:
+    assert is_attempted_action(output) is expected
+
+
+@pytest.mark.asyncio
+async def test_run_retries_when_attempted_action_is_malformed(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+        fake_prompt_service: FakePromptService,
+        fake_agent_tool_service: FakeAgentToolService,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat([
+            MALFORMED_TOOL_CALL,
+            '{"action":"FINAL","content":"review-complete"}',
+        ]),
+    )
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.stop_reason == "final"
+    assert result.final_text == "review-complete"
+    assert MALFORMED_TOOL_CALL not in result.final_text
+    assert len(result.traces) == 2
+    assert result.traces[0].step is None
+    assert result.traces[0].raw_output == MALFORMED_TOOL_CALL
+    assert "Invalid response discarded" in (result.traces[0].warning or "")
+    assert fake_agent_tool_service.calls == []
+    assert [
+        call[1]["force_final"] for call in fake_prompt_service.calls
+        if call[0] == "build_agent_request"
+    ] == [False, False]
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_execute_the_command_of_a_malformed_action(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+        fake_agent_tool_service: FakeAgentToolService,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat([
+            MALFORMED_TOOL_CALL,
+            '{"action":"TOOL_CALL","command":"ls"}',
+            '{"action":"FINAL","content":"done"}',
+        ]),
+    )
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.final_text == "done"
+    assert fake_agent_tool_service.calls == [("execute", {"command": "ls"})]
+
+
+@pytest.mark.asyncio
+async def test_run_counts_tokens_of_a_discarded_attempted_action(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat_results([
+            ChatResultSchema(
+                text=MALFORMED_TOOL_CALL,
+                total_tokens=30,
+                prompt_tokens=10,
+                completion_tokens=20,
+            ),
+            ChatResultSchema(
+                text='{"action":"FINAL","content":"done"}',
+                total_tokens=15,
+                prompt_tokens=5,
+                completion_tokens=10,
+            ),
+        ]),
+    )
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.final_text == "done"
+    assert result.total_tokens == 45
+
+
+@pytest.mark.asyncio
+async def test_run_forces_final_when_malformed_actions_exhaust_the_budget(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+        fake_prompt_service: FakePromptService,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat([
+            MALFORMED_TOOL_CALL,
+            MALFORMED_TOOL_CALL,
+            MALFORMED_TOOL_CALL,
+            '{"action":"FINAL","content":"forced-final"}',
+        ]),
+    )
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.final_text == "forced-final"
+    assert MALFORMED_TOOL_CALL not in result.final_text
+    assert any(
+        call[0] == "build_agent_request" and call[1]["force_final"] is True
+        for call in fake_prompt_service.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_resets_the_malformed_action_budget_between_runs(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+) -> None:
+    for expected in ("one", "two"):
+        monkeypatch.setattr(
+            fake_llm_client,
+            "chat",
+            sequence_chat([
+                MALFORMED_TOOL_CALL,
+                MALFORMED_TOOL_CALL,
+                f'{{"action":"FINAL","content":"{expected}"}}',
+            ]),
+        )
+
+        result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+        assert result.stop_reason == "final"
+        assert result.final_text == expected
+
+
+@pytest.mark.asyncio
+async def test_run_returns_markdown_summary_as_final_text(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+) -> None:
+    monkeypatch.setattr(fake_llm_client, "chat", sequence_chat([MARKDOWN_SUMMARY]))
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.stop_reason == "unstructured_response"
+    assert result.final_text == MARKDOWN_SUMMARY
+    assert len(result.traces) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_returns_inline_comment_json_array_as_final_text(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+) -> None:
+    monkeypatch.setattr(fake_llm_client, "chat", sequence_chat([INLINE_COMMENTS_JSON]))
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.stop_reason == "unstructured_response"
+    assert result.final_text == INLINE_COMMENTS_JSON
+    assert len(result.traces) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_recovers_from_reasoning_delimiter_before_the_action(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+        fake_agent_tool_service: FakeAgentToolService,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat([
+            REASONING_PREFIXED_TOOL_CALL,
+            '{"action":"TOOL_CALL","command":"cat modules/Sample.java"}',
+            '{"action":"FINAL","content":"review-complete"}',
+        ]),
+    )
+    fake_agent_tool_service.responses["execute"] = "class Sample {}"
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.stop_reason == "final"
+    assert result.final_text == "review-complete"
+    assert fake_agent_tool_service.calls == [("execute", {"command": "cat modules/Sample.java"})]
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_promote_prose_wrapped_action_to_final_text(
+        monkeypatch: pytest.MonkeyPatch,
+        agent_loop_service: AgentLoopService,
+        fake_llm_client: FakeLLMClient,
+) -> None:
+    monkeypatch.setattr(
+        fake_llm_client,
+        "chat",
+        sequence_chat([
+            PROSE_WRAPPED_TOOL_CALL,
+            '{"action":"FINAL","content":"review-complete"}',
+        ]),
+    )
+
+    result = await agent_loop_service.run("PROMPT", "SYSTEM")
+
+    assert result.final_text == "review-complete"
+    assert result.final_text != PROSE_WRAPPED_TOOL_CALL

--- a/ai_review/tests/suites/services/prompt/test_tools.py
+++ b/ai_review/tests/suites/services/prompt/test_tools.py
@@ -225,3 +225,16 @@ def test_format_traces_joins_entries_with_separator():
     assert "Iteration: 1" in result
     assert "Iteration: 2" in result
     assert "\n\n---\n\n" in result
+
+
+def test_format_trace_without_step_renders_warning_only():
+    trace = AgentTraceSchema(
+        iteration=2,
+        warning="Invalid response discarded: it carried an agent action but was not a single valid JSON object.",
+        raw_output='{"action":"TOOL_CALL","command":"git grep -n "x" -- docs"}',
+    )
+    result = format_trace(trace)
+    assert "Iteration: 2" in result
+    assert "Invalid response discarded" in result
+    assert "Command:" not in result
+    assert "Content:" not in result


### PR DESCRIPTION
## Problem

`AgentLoopService.run` returns any response that `parse_output` cannot parse as
`final_text` and stops the loop:

```python
step: AgentStepSchema | None = self.parser.parse_output(result.text)
if step is None:
    fallback_text = result.text or ""
    logger.info(f"Agent loop iteration {iteration} returned unstructured response; stopping")
    ...
    return AgentLoopResultSchema(
        traces=self.traces,
        final_text=fallback_text,
        stop_reason="unstructured_response",
    )
```

That fallback is correct and necessary for a genuine final answer: the task prompt asks
for plain Markdown or a JSON array of inline comments, and neither parses as an
`AgentStepSchema`.

It is wrong for a malformed `TOOL_CALL`. A `TOOL_CALL` command is nested three levels
deep (JSON string -> shell argv -> search pattern), so every `"` inside a command must be
escaped as `\"`, and models intermittently miss one. When that happens the agent's
investigation ends mid-flight — the file under review gets no findings at all — and the
broken JSON is posted verbatim as the review comment.

I measured this on my own CI across four runs of one merge request, counting only
responses short enough to judge in full: roughly **2-4% of model responses** carried a
malformed action, on **two different models from the same family (Opus/Sonnet)**, so it is
not model-specific or prompt-specific. In one run the malformed action happened while the
agent was investigating the largest file in the diff; that file received zero comments,
where a comparable run produced three.

## Reproduction

Save as `repro.py` in the repository root and run
`AI_REVIEW_CONFIG_FILE_YAML=./ai_review/tests/configs/config-test.yaml python repro.py`:

```python
import asyncio

from ai_review.services.agent.loop.service import AgentLoopService
from ai_review.services.llm.types import ChatResultSchema

MALFORMED_ACTION = '{"action":"TOOL_CALL","command":"git grep -n -i -l "migration" -- docs"}'
FINAL_ANSWER = '{"action":"FINAL","content":"## Review\\n\\n- No issues found."}'
15

class FakeLLM:
    def __init__(self, outputs: list[str]):
        self.outputs = outputs

    async def chat(self, prompt: str, prompt_system: str) -> ChatResultSchema:
        return ChatResultSchema(text=self.outputs.pop(0))


class FakePrompt:
    def build_agent_request(self, traces, force_final, original_prompt, original_prompt_system) -> str:
        return "AGENT_PROMPT"

    def build_system_agent_request(self) -> str:
        return "SYSTEM_AGENT_PROMPT"


class FakeTool:
    async def execute(self, command: str) -> str:
        return "TOOL_OUTPUT"


async def main() -> None:
    loop = AgentLoopService(
        llm=FakeLLM([MALFORMED_ACTION, FINAL_ANSWER]),
        prompt=FakePrompt(),
        agent_tool=FakeTool(),
    )
    result = await loop.run("Review the diff", "Return a Markdown summary")
    print("stop_reason:", result.stop_reason)
    print("final_text:", repr(result.final_text))


asyncio.run(main())
```

Before this change the model's second, perfectly valid `FINAL` is never requested:

```
INFO | AGENT_LOOP_SERVICE | Agent loop iteration 1 returned unstructured response; stopping
stop_reason: unstructured_response
final_text: '{"action":"TOOL_CALL","command":"git grep -n -i -l "migration" -- docs"}'
```

After:

```
WARNING | AGENT_LOOP_SERVICE | Agent loop iteration 1 returned an unparseable action (1/2 tolerated); discarding it instead of using it as the final answer
stop_reason: final
final_text: '## Review\n\n- No issues found.'
```

## What this changes

When `parse_output` returns `None`, the loop now asks one question: did the model *try*
to speak the agent protocol? The test is the presence of the protocol envelope — an
`action` key whose value is one of `AgentAction`'s own names, with the alternation
generated from the enum so the two cannot drift:

```python
AGENT_ACTION_ENVELOPE_RE = re.compile(
    rf"""["']action["']\s*:\s*["']({"|".join(AgentAction)})["']""",
    re.IGNORECASE,
)
```

* **Envelope present** — the turn is a protocol violation, not an answer. It is discarded,
  recorded in the trace history with a corrective warning so the next prompt differs from
  the one that failed, and the loop retries. Two violations per run are tolerated; after
  that the loop enters the existing force-final flow and answers from the evidence it has
  already gathered. The raw output is never promoted to `final_text`.
* **Envelope absent** — nothing changes. A plain-Markdown summary or a JSON array of
  inline comments is returned exactly as before, with `stop_reason="unstructured_response"`.

Two properties worth calling out:

* **A retry costs nothing extra overall.** A retry consumes a loop iteration, so the
  worst-case number of requests is unchanged at `max_iterations + 1`.
* **The retry cannot be a no-op.** With a deterministic provider at `temperature: 0`,
  re-sending an identical prompt returns an identical response, so the corrective warning
  goes into the trace history and therefore into the next prompt.

Why retry rather than force-final on the first violation: at a 2-4% per-response rate,
18-33% of 10-turn investigations and 40-64% of 25-turn investigations contain at least one
malformed turn, so single-strike handling would truncate a large share of them. With two
tolerated violations a run needs three malformed turns in total before it force-finalizes
— about 0.1-0.6% of 10-turn runs and 1.3-7.7% of 25-turn runs — and even then it answers
from the evidence gathered rather than returning the broken text. For the raw text to
reach a comment at all, the forced-final turn would have to be malformed too, which puts
that outcome well under 1%.

## Observed recovering a live model

The reproduction above is synthetic. The same thing then happened unprompted during an ordinary review run — this branch built into the container image we run in CI, in dry-run mode so nothing was posted, against a real merge request. Part-way through the summary stage the model emitted a malformed action, the loop discarded it, and the review finished instead of ending there.

Excerpt from that run. File paths and search patterns are redacted; the log lines, the parse error and the quoting are otherwise verbatim.

````
| DEBUG   | AGENT_LOOP_SERVICE | Agent LLM response at iteration 2: ```json
{"action":"TOOL_CALL","command":"rg -n "migration|alembic|CREATE TABLE|ALTER TABLE" src/db.py"}
```
| WARNING | LLM_JSON_PARSER    | [AgentStepSchema] Raw JSON parse failed: 1 validation error for AgentStepSchema
  Invalid JSON: expected `,` or `}` at line 1 column 41 [type=json_invalid, ...]
| ERROR   | LLM_JSON_PARSER    | [AgentStepSchema] No valid JSON found in output
| WARNING | AGENT_LOOP_SERVICE | Agent loop iteration 2 returned an unparseable action (1/2 tolerated);
                                discarding it instead of using it as the final answer
| DEBUG   | AGENT_LOOP_SERVICE | Agent loop iteration started: 3
| DEBUG   | AGENT_LOOP_SERVICE | Agent prompt for iteration 3 (prompt_chars=20032, traces=2)
| DEBUG   | AGENT_LOOP_SERVICE | Agent LLM response at iteration 3: ```json
{"action":"TOOL_CALL","command":"grep -n \"…\" src/db.py"}
```
| INFO    | LLM_JSON_PARSER    | [AgentStepSchema] Successfully parsed
| DEBUG   | AGENT_LOOP_SERVICE | Executing agent tool command at iteration 3
...
AI review completed successfully!
````

The unescaped `"` before `migration` closes the JSON string early, so the parse fails at column 41 — the exact failure this PR is about, produced by the model on its own rather than by a fixture. Before this change that response would have become `final_text` with `stop_reason="unstructured_response"`; because it happened during the summary stage, the broken JSON would have been posted as the merge request's review comment.

Two caveats, so this is not read as more than it is. It is a single observation, not a recovery rate: I cannot say from one run how often a model recovers after the corrective warning, only that this one did, and that its next action escaped its quotes correctly. And iteration 3 is a *different* search rather than a retry of the failed one — the change does not ask the model to repeat itself, it only stops a broken action from ending the run.

The Sonnet run above contained one malformed action; an Opus run in the same session contained none across 51 tool calls. That is what a 2-4% per-response rate looks like in practice — intermittent, and easy to miss until it costs a review.

## This is not another parser heuristic

Issue #96 was closed with the reasoning that the parser "is intentionally built around strict
JSON output, with only limited recovery", that it should not grow "into a growing set of
heuristics for protocol-violating model responses", and that the proposed
`iter_json_candidates()` was "still heuristic recovery logic, not actual protocol
handling".

I am not asking to revisit that, and this change does not touch `LLMOutputJSONParser`. It
never inspects, extracts, recovers or repairs the payload — the broken text is discarded
unread. It only changes what the loop *does* when a turn violates the protocol: an
attempted action must not become the final review.

## Related issues and PRs

* **#115** (open, GLM-5.2 in agent mode) — this improves both reported symptoms without
  claiming to close the issue, and both are covered by tests.
  An action object can no longer be promoted from the loop into the summary comment, and
  `</think>{"action":"TOOL_CALL",...}` no longer stops the loop where it occurs: the turn
  is discarded and retried. The report describes this as something the model "may return",
  i.e. intermittently, and that is the case this change recovers. To be precise about what
  it does **not** do: a model that emits the delimiter on *every* turn would spend the
  retries and reach the force-final turn, because stripping the prefix would be payload
  recovery of exactly the kind #96 was closed for. So this makes agent mode survivable for
  that model rather than fully compatible with it.
* **#108** (closed) — **this PR does not fix #108 and does not claim to.** The payload
  reported there is a JSON array of inline comments, which is the *intended* final answer
  for that task; the `Raw JSON parse failed` warning is the parser logging on its way to
  the fallback that then returns the array correctly. That path is exactly what must not
  regress when the loop starts treating some unparseable responses differently, so I added
  `test_run_returns_inline_comment_json_array_as_final_text` to pin it: the array is still
  returned unchanged, with the same `stop_reason`. I mention #108 only as the regression
  I had to guard against.
* **#96** (closed) — its description reports the same failure class from other model
  families: prose before the JSON object, or two concatenated JSON objects. Both carry the
  protocol envelope, so both are now discarded and retried instead of being promoted to
  the final answer.

## One schema change

`AgentTraceSchema.step` becomes `AgentStepSchema | None = None` (backward compatible), and
`format_trace` guards on it. A discarded turn produced no step, and inventing a synthetic
`FINAL` step for it — as the two terminal branches in this file do — would render the
discarded garbage into the next prompt as `Content:`, i.e. as an answer the agent had
already given. The raw output stays on `trace.raw_output` for artifacts and debugging but
is deliberately kept out of the next prompt, so the model is not invited to copy it.

## Tests

18 new cases:

* `test_is_attempted_action_detects_the_protocol_envelope` — the discriminator, 8
  parametrized cases, including a lowercase `"action": "final"` that must match and
  near-miss prose (`The action taken by the FINAL migration is unclear`) that must not.
* `test_run_retries_when_attempted_action_is_malformed` — the reproduction above, plus the
  discarded trace's shape and the fact that a second non-force-final prompt is built.
* `test_run_does_not_execute_the_command_of_a_malformed_action`
* `test_run_counts_tokens_of_a_discarded_attempted_action`
* `test_run_forces_final_when_malformed_actions_exhaust_the_budget`
* `test_run_resets_the_malformed_action_budget_between_runs`
* `test_run_returns_markdown_summary_as_final_text` — regression guard.
* `test_run_returns_inline_comment_json_array_as_final_text` — regression guard (#108's
  payload shape).
* `test_run_recovers_from_reasoning_delimiter_before_the_action` — #115.
* `test_run_does_not_promote_prose_wrapped_action_to_final_text` — #115.
* `test_format_trace_without_step_renders_warning_only`

Against the unchanged loop (with only the new `is_attempted_action` helper present so the
module imports), 8 of these fail: the seven loop-behavior tests and the step-less trace
rendering. The two regression guards pass before and after — that is their purpose.

`AI_REVIEW_CONFIG_FILE_YAML=./ai_review/tests/configs/config-test.yaml pytest` — 775
passed, up from 757.

## Notes for review

* `MAX_PROTOCOL_VIOLATIONS = 2` is a module constant exposed as an instance attribute; no
  new configuration key. Happy to lift it into `AgentConfig` if you would rather it be
  tunable.
* The budget is cumulative per run and is reset by `clear()`, so it cannot leak between
  files in a review.
* The force-final path keeps its existing `max_requests_or_context_limit` stop reason; I
  did not add a new one, to keep the diff small. Say the word if you want the cause
  distinguishable from a real limit.
* `force_final`'s own last-resort promotion is intentionally unchanged: reaching it with an
  unparseable action now requires four malformed turns in a single run, and at that point
  there is no better answer available than the raw text. It logs a warning if it happens.
* Structured output (tool calling, or a `response_format` JSON schema) would remove this
  failure class at the source rather than making it survivable, but it needs new
  per-provider request fields and is a much larger change, so it is deliberately not part
  of this PR.
