### PR TITLE
Fixed GitLab CI/CD deployment descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,17 @@ For GitLab users:
 
 ```yaml
 ai-review:
-  when: manual
   stage: review
   image: nikitafilonov/ai-review:latest
   rules:
     - if: '$CI_MERGE_REQUEST_IID'
+      when: manual
   script:
     - ai-review run
   variables:
+    # --- Mandatory ---
+    GIT_DEPTH: "0"
+
     # --- LLM configuration ---
     LLM__PROVIDER: "OPENAI"
     LLM__META__MODEL: "gpt-4o-mini"


### PR DESCRIPTION
### Summary 

This merge request updates the GitLab CI/CD deployment example in the README to include the required parameter GIT_DEPTH: 0 and moves the `when: manual` directive to the rules section.

### Details

1. The [gitlab.yaml example](https://github.com/Nikita-Filonov/ai-review/blob/81a12425be5b7b677693bf0904bc1f8b10e6d754/docs/ci/gitlab.yaml#L12) specifies this parameter as required, but it seems to be missing from the main README, so following the README as written would produce an incorrect setup.
2. Adjusted the placement of `when: manual`, moving it from the top level of the job definition into the rules block. While the current placement of `when` is working correctly with newest versions of GitLab, the review bot itself will warn developers that, when using a `rules` Block, `when` should be placed inside of it. This configuration choice eliminates that warning. 