### PR TITLE
chore(deps): migrate httpx to httpx2

### DIFF
--- a/ai_review/clients/azure_devops/client.py
+++ b/ai_review/clients/azure_devops/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.azure_devops.pr.client import AzureDevOpsPullRequestsHTTPClient
 from ai_review.clients.azure_devops.tools import build_azure_devops_headers

--- a/ai_review/clients/azure_devops/pr/client.py
+++ b/ai_review/clients/azure_devops/pr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.azure_devops.pr.schema.files import (
     AzureDevOpsPRChangeSchema,

--- a/ai_review/clients/azure_devops/tools.py
+++ b/ai_review/clients/azure_devops/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 from ai_review.config import settings
 from ai_review.libs.config.vcs.azure_devops import AzureDevOpsTokenType

--- a/ai_review/clients/azure_openai/client.py
+++ b/ai_review/clients/azure_openai/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, AsyncHTTPTransport, AsyncClient, QueryParams
+from httpx2 import Response, AsyncHTTPTransport, AsyncClient, QueryParams
 
 from ai_review.clients.azure_openai.schema import (
     AzureOpenAIChatQuerySchema,

--- a/ai_review/clients/bedrock/client.py
+++ b/ai_review/clients/bedrock/client.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote
 
-from httpx import Response, AsyncHTTPTransport, AsyncClient
+from httpx2 import Response, AsyncHTTPTransport, AsyncClient
 
 from ai_review.clients.bedrock.schema import BedrockChatRequestSchema, BedrockChatResponseSchema
 from ai_review.clients.bedrock.types import BedrockHTTPClientProtocol

--- a/ai_review/clients/bitbucket_cloud/client.py
+++ b/ai_review/clients/bitbucket_cloud/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.bitbucket_cloud.pr.client import BitbucketCloudPullRequestsHTTPClient
 from ai_review.config import settings

--- a/ai_review/clients/bitbucket_cloud/pr/client.py
+++ b/ai_review/clients/bitbucket_cloud/pr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.bitbucket_cloud.pr.schema.comments import (
     BitbucketCloudPRCommentSchema,

--- a/ai_review/clients/bitbucket_cloud/tools.py
+++ b/ai_review/clients/bitbucket_cloud/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 
 def bitbucket_cloud_has_next_page(response: Response) -> bool:

--- a/ai_review/clients/bitbucket_server/client.py
+++ b/ai_review/clients/bitbucket_server/client.py
@@ -1,5 +1,5 @@
 from ai_review.clients.bitbucket_server.pr.client import BitbucketServerPullRequestsHTTPClient
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.config import settings
 from ai_review.libs.http.event_hooks.logger import LoggerEventHook

--- a/ai_review/clients/bitbucket_server/pr/client.py
+++ b/ai_review/clients/bitbucket_server/pr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.bitbucket_server.pr.schema.activities import (
     BitbucketServerActivitySchema,

--- a/ai_review/clients/bitbucket_server/tools.py
+++ b/ai_review/clients/bitbucket_server/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 
 def bitbucket_server_has_next_page(response: Response) -> bool:

--- a/ai_review/clients/claude/client.py
+++ b/ai_review/clients/claude/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, Response, AsyncHTTPTransport
+from httpx2 import AsyncClient, Response, AsyncHTTPTransport
 
 from ai_review.clients.claude.schema import ClaudeChatRequestSchema, ClaudeChatResponseSchema
 from ai_review.clients.claude.types import ClaudeHTTPClientProtocol

--- a/ai_review/clients/gemini/client.py
+++ b/ai_review/clients/gemini/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, AsyncHTTPTransport, AsyncClient
+from httpx2 import Response, AsyncHTTPTransport, AsyncClient
 
 from ai_review.clients.gemini.schema import GeminiChatRequestSchema, GeminiChatResponseSchema
 from ai_review.clients.gemini.types import GeminiHTTPClientProtocol

--- a/ai_review/clients/gitea/client.py
+++ b/ai_review/clients/gitea/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.gitea.pr.client import GiteaPullRequestsHTTPClient
 from ai_review.config import settings

--- a/ai_review/clients/gitea/pr/client.py
+++ b/ai_review/clients/gitea/pr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.gitea.pr.schema.comments import (
     GiteaPRCommentSchema,

--- a/ai_review/clients/gitea/tools.py
+++ b/ai_review/clients/gitea/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 
 def gitea_has_next_page(response: Response) -> bool:

--- a/ai_review/clients/github/client.py
+++ b/ai_review/clients/github/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.github.pr.client import GitHubPullRequestsHTTPClient
 from ai_review.config import settings

--- a/ai_review/clients/github/pr/client.py
+++ b/ai_review/clients/github/pr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.github.pr.schema.comments import (
     GitHubPRCommentSchema,

--- a/ai_review/clients/github/tools.py
+++ b/ai_review/clients/github/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 
 def github_has_next_page(response: Response) -> bool:

--- a/ai_review/clients/gitlab/client.py
+++ b/ai_review/clients/gitlab/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, AsyncHTTPTransport
+from httpx2 import AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.gitlab.mr.client import GitLabMergeRequestsHTTPClient
 from ai_review.config import settings

--- a/ai_review/clients/gitlab/mr/client.py
+++ b/ai_review/clients/gitlab/mr/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, QueryParams
+from httpx2 import Response, QueryParams
 
 from ai_review.clients.gitlab.mr.schema.changes import GitLabGetMRChangesResponseSchema
 from ai_review.clients.gitlab.mr.schema.discussions import (

--- a/ai_review/clients/gitlab/tools.py
+++ b/ai_review/clients/gitlab/tools.py
@@ -1,4 +1,4 @@
-from httpx import Response
+from httpx2 import Response
 
 
 def gitlab_has_next_page(response: Response) -> bool:

--- a/ai_review/clients/ollama/client.py
+++ b/ai_review/clients/ollama/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, Response, AsyncHTTPTransport
+from httpx2 import AsyncClient, Response, AsyncHTTPTransport
 
 from ai_review.clients.ollama.schema import OllamaChatRequestSchema, OllamaChatResponseSchema
 from ai_review.clients.ollama.types import OllamaHTTPClientProtocol

--- a/ai_review/clients/openai/v1/client.py
+++ b/ai_review/clients/openai/v1/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, AsyncHTTPTransport, AsyncClient
+from httpx2 import Response, AsyncHTTPTransport, AsyncClient
 
 from ai_review.clients.openai.v1.schema import OpenAIChatRequestSchema, OpenAIChatResponseSchema
 from ai_review.clients.openai.v1.types import OpenAIV1HTTPClientProtocol

--- a/ai_review/clients/openai/v2/client.py
+++ b/ai_review/clients/openai/v2/client.py
@@ -1,4 +1,4 @@
-from httpx import Response, AsyncClient, AsyncHTTPTransport
+from httpx2 import Response, AsyncClient, AsyncHTTPTransport
 
 from ai_review.clients.openai.v2.schema import (
     OpenAIResponsesRequestSchema,

--- a/ai_review/clients/openrouter/client.py
+++ b/ai_review/clients/openrouter/client.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient, Response, AsyncHTTPTransport
+from httpx2 import AsyncClient, Response, AsyncHTTPTransport
 
 from ai_review.clients.openrouter.schema import OpenRouterChatRequestSchema, OpenRouterChatResponseSchema
 from ai_review.clients.openrouter.types import OpenRouterHTTPClientProtocol

--- a/ai_review/libs/http/client.py
+++ b/ai_review/libs/http/client.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from httpx import AsyncClient, Response, QueryParams
-from httpx._types import HeaderTypes, RequestContent
+from httpx2 import AsyncClient, Response, QueryParams
+from httpx2._types import HeaderTypes, RequestContent
 
 
 class HTTPClient:

--- a/ai_review/libs/http/event_hooks/base.py
+++ b/ai_review/libs/http/event_hooks/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from httpx import Request, Response
+from httpx2 import Request, Response
 
 
 class BaseEventHook(ABC):

--- a/ai_review/libs/http/event_hooks/logger.py
+++ b/ai_review/libs/http/event_hooks/logger.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from httpx import Request, Response
+from httpx2 import Request, Response
 
 from ai_review.libs.http.event_hooks.base import BaseEventHook
 

--- a/ai_review/libs/http/handlers.py
+++ b/ai_review/libs/http/handlers.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Callable, Coroutine, Any
 
-from httpx import Response, HTTPStatusError
+from httpx2 import Response, HTTPStatusError
 
 APIFunc = Callable[..., Coroutine[Any, Any, Response]]
 

--- a/ai_review/libs/http/paginate.py
+++ b/ai_review/libs/http/paginate.py
@@ -1,6 +1,6 @@
 from typing import Awaitable, Callable, TypeVar
 
-from httpx import Response
+from httpx2 import Response
 from pydantic import BaseModel
 
 from ai_review.libs.logger import get_logger

--- a/ai_review/libs/http/transports/retry.py
+++ b/ai_review/libs/http/transports/retry.py
@@ -2,7 +2,7 @@ import asyncio
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
-from httpx import Request, Response, AsyncBaseTransport
+from httpx2 import Request, Response, AsyncBaseTransport
 
 if TYPE_CHECKING:
     from loguru import Logger

--- a/ai_review/tests/suites/clients/azure_devops/test_client.py
+++ b/ai_review/tests/suites/clients/azure_devops/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.azure_devops.client import get_azure_devops_http_client, AzureDevOpsHTTPClient
 from ai_review.clients.azure_devops.pr.client import AzureDevOpsPullRequestsHTTPClient

--- a/ai_review/tests/suites/clients/azure_devops/test_tools.py
+++ b/ai_review/tests/suites/clients/azure_devops/test_tools.py
@@ -1,7 +1,7 @@
 import base64
 
 import pytest
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review import config
 from ai_review.clients.azure_devops.tools import azure_devops_extract_continuation_token, build_azure_devops_headers
@@ -13,7 +13,7 @@ def make_response(
         headers: dict | None = None,
         text_data: str | None = None,
 ) -> Response:
-    """Helper to build httpx.Response with either JSON or raw text body."""
+    """Helper to build httpx2.Response with either JSON or raw text body."""
     request = Request("GET", "http://azure.test")
 
     if json_data is not None:

--- a/ai_review/tests/suites/clients/azure_openai/test_client.py
+++ b/ai_review/tests/suites/clients/azure_openai/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.azure_openai.client import get_azure_openai_http_client, AzureOpenAIHTTPClient
 

--- a/ai_review/tests/suites/clients/bedrock/test_client.py
+++ b/ai_review/tests/suites/clients/bedrock/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.bedrock.client import get_bedrock_http_client, BedrockHTTPClient
 

--- a/ai_review/tests/suites/clients/bitbucket_cloud/test_client.py
+++ b/ai_review/tests/suites/clients/bitbucket_cloud/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.bitbucket_cloud.client import get_bitbucket_cloud_http_client, BitbucketCloudHTTPClient
 from ai_review.clients.bitbucket_cloud.pr.client import BitbucketCloudPullRequestsHTTPClient

--- a/ai_review/tests/suites/clients/bitbucket_cloud/test_tools.py
+++ b/ai_review/tests/suites/clients/bitbucket_cloud/test_tools.py
@@ -1,4 +1,4 @@
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review.clients.bitbucket_cloud.tools import bitbucket_cloud_has_next_page
 

--- a/ai_review/tests/suites/clients/bitbucket_server/test_client.py
+++ b/ai_review/tests/suites/clients/bitbucket_server/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.bitbucket_server.client import get_bitbucket_server_http_client, BitbucketServerHTTPClient
 from ai_review.clients.bitbucket_server.pr.client import BitbucketServerPullRequestsHTTPClient

--- a/ai_review/tests/suites/clients/bitbucket_server/test_tools.py
+++ b/ai_review/tests/suites/clients/bitbucket_server/test_tools.py
@@ -1,6 +1,6 @@
 import json
 
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review.clients.bitbucket_server.tools import bitbucket_server_has_next_page
 

--- a/ai_review/tests/suites/clients/claude/test_client.py
+++ b/ai_review/tests/suites/clients/claude/test_client.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from httpx import AsyncClient, MockTransport, Request, Response
+from httpx2 import AsyncClient, MockTransport, Request, Response
 
 from ai_review.clients.claude.client import get_claude_http_client, ClaudeHTTPClient
 from ai_review.clients.claude.schema import ClaudeChatRequestSchema, ClaudeMessageSchema

--- a/ai_review/tests/suites/clients/gemini/test_client.py
+++ b/ai_review/tests/suites/clients/gemini/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.gemini.client import get_gemini_http_client, GeminiHTTPClient
 

--- a/ai_review/tests/suites/clients/gitea/test_client.py
+++ b/ai_review/tests/suites/clients/gitea/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.gitea.client import get_gitea_http_client, GiteaHTTPClient
 from ai_review.clients.gitea.pr.client import GiteaPullRequestsHTTPClient

--- a/ai_review/tests/suites/clients/gitea/test_tools.py
+++ b/ai_review/tests/suites/clients/gitea/test_tools.py
@@ -1,4 +1,4 @@
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review.clients.gitea.tools import gitea_has_next_page
 

--- a/ai_review/tests/suites/clients/github/test_client.py
+++ b/ai_review/tests/suites/clients/github/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.github.client import get_github_http_client, GitHubHTTPClient
 from ai_review.clients.github.pr.client import GitHubPullRequestsHTTPClient

--- a/ai_review/tests/suites/clients/github/test_tools.py
+++ b/ai_review/tests/suites/clients/github/test_tools.py
@@ -1,4 +1,4 @@
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review.clients.github.tools import github_has_next_page
 

--- a/ai_review/tests/suites/clients/gitlab/test_client.py
+++ b/ai_review/tests/suites/clients/gitlab/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient, MockTransport, Request, Response
+from httpx2 import AsyncClient, MockTransport, Request, Response
 
 from ai_review.clients.gitlab.client import get_gitlab_http_client, GitLabHTTPClient
 from ai_review.clients.gitlab.mr.client import GitLabMergeRequestsHTTPClient

--- a/ai_review/tests/suites/clients/gitlab/test_tools.py
+++ b/ai_review/tests/suites/clients/gitlab/test_tools.py
@@ -1,4 +1,4 @@
-from httpx import Response, Request
+from httpx2 import Response, Request
 
 from ai_review.clients.gitlab.tools import gitlab_has_next_page
 

--- a/ai_review/tests/suites/clients/ollama/test_client.py
+++ b/ai_review/tests/suites/clients/ollama/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.ollama.client import get_ollama_http_client, OllamaHTTPClient
 

--- a/ai_review/tests/suites/clients/openai/v1/test_client.py
+++ b/ai_review/tests/suites/clients/openai/v1/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.openai.v1.client import get_openai_v1_http_client, OpenAIV1HTTPClient
 

--- a/ai_review/tests/suites/clients/openai/v2/test_client.py
+++ b/ai_review/tests/suites/clients/openai/v2/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.openai.v2.client import get_openai_v2_http_client, OpenAIV2HTTPClient
 

--- a/ai_review/tests/suites/clients/openrouter/test_client.py
+++ b/ai_review/tests/suites/clients/openrouter/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 from ai_review.clients.openrouter.client import get_openrouter_http_client, OpenRouterHTTPClient
 

--- a/ai_review/tests/suites/libs/http/test_paginate.py
+++ b/ai_review/tests/suites/libs/http/test_paginate.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import Response, Request
+from httpx2 import Response, Request
 from pydantic import BaseModel
 
 from ai_review.libs.http.paginate import paginate, paginate_with_token

--- a/ai_review/tests/suites/libs/http/transports/test_retry.py
+++ b/ai_review/tests/suites/libs/http/transports/test_retry.py
@@ -1,20 +1,20 @@
-import httpx
+import httpx2
 import pytest
 
 from ai_review.libs.http.transports.retry import NO_RETRY, RetryTransport
 from ai_review.libs.logger import get_logger
 
 
-class CountingTransport(httpx.AsyncBaseTransport):
+class CountingTransport(httpx2.AsyncBaseTransport):
     """Inner transport that always answers with the same status and counts attempts."""
 
     def __init__(self, status_code: int):
         self.status_code = status_code
         self.attempts = 0
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         self.attempts += 1
-        return httpx.Response(self.status_code, request=request)
+        return httpx2.Response(self.status_code, request=request)
 
 
 def build_retry_transport(inner: CountingTransport) -> RetryTransport:
@@ -32,7 +32,7 @@ async def test_retry_transport_retries_server_errors():
     inner = CountingTransport(status_code=500)
     transport = build_retry_transport(inner)
 
-    response = await transport.handle_async_request(httpx.Request("POST", "https://gitlab.test/api"))
+    response = await transport.handle_async_request(httpx2.Request("POST", "https://gitlab.test/api"))
 
     assert response.status_code == 500
     assert inner.attempts == 3
@@ -43,7 +43,7 @@ async def test_retry_transport_does_not_retry_when_opted_out():
     """Should make a single attempt for a request marked as non-idempotent."""
     inner = CountingTransport(status_code=500)
     transport = build_retry_transport(inner)
-    request = httpx.Request("POST", "https://gitlab.test/api", extensions=NO_RETRY)
+    request = httpx2.Request("POST", "https://gitlab.test/api", extensions=NO_RETRY)
 
     response = await transport.handle_async_request(request)
 
@@ -57,7 +57,7 @@ async def test_retry_transport_returns_success_without_retrying():
     inner = CountingTransport(status_code=200)
     transport = build_retry_transport(inner)
 
-    response = await transport.handle_async_request(httpx.Request("GET", "https://gitlab.test/api"))
+    response = await transport.handle_async_request(httpx2.Request("GET", "https://gitlab.test/api"))
 
     assert response.status_code == 200
     assert inner.attempts == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 description = "AI-powered code review tool for GitHub, GitLab, Bitbucket Cloud, Bitbucket Server, Azure DevOps and Gitea — built with LLMs like OpenAI, Claude, Gemini, Ollama, Bedrock, OpenRouter and Azure OpenAI"
 dependencies = [
     "typer",
-    "httpx",
+    "httpx2>=2.12,<3",
     "pyyaml",
     "loguru",
     "aiofiles",


### PR DESCRIPTION
httpx has been effectively unmaintained since late 2024: no commits on any branch since 2026-03-29, and the GitHub issue tracker is disabled. The 1.0.dev4/1.0.dev5 releases that appeared on PyPI this month ship with no corresponding commits, changelog, or release notes — there's no way to review what changed in them.

httpx2 is a pydantic-maintained fork of the same codebase (from httpx 0.28.1) that picks up stewardship, including a security-response process. Public API is unchanged — same Client, AsyncClient, Response, Auth, Limits, Timeout, ASGITransport/WSGITransport — so this is a straight import rename with no other code changes needed.

Pinned as httpx2>=2.12,<3; it's young and ships roughly weekly, so an upper bound seemed worth having until it settles.

Note for reviewers: httpx2 verifies TLS against the OS trust store (via truststore) instead of bundling certifi. HTTPClientConfig.verify here is only ever a bool or None in the configs I found in this repo, so this shouldn't change behavior in practice, but it's worth knowing if a deployment sets a custom CA bundle path — that still works but now emits a DeprecationWarning.